### PR TITLE
Added support for displaytitle

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -30,6 +30,9 @@
 		"PageNetworkExcludedNamespaces": {
 			"value": [ 2, 4, 8, 12 ]
 		},
+		"PageNetworkDefaultEnableDisplayTitle": {
+			"value": true
+		},
 		"PageNetworkDefaultLabelMaxLength": {
 			"value": 20
 		}

--- a/extension.json
+++ b/extension.json
@@ -29,6 +29,9 @@
 		},
 		"PageNetworkExcludedNamespaces": {
 			"value": [ 2, 4, 8, 12 ]
+		},
+		"PageNetworkDefaultLabelMaxLength": {
+			"value": 20
 		}
 	},
 

--- a/resources/js/ApiPageConnectionRepo.js
+++ b/resources/js/ApiPageConnectionRepo.js
@@ -42,8 +42,18 @@ module.ApiPageConnectionRepo = ( function ( mw, ApiConnectionsBuilder ) {
 						.filter(p => p.missing === '')
 						.map(p => p.title);
 
+					let displaytitles = [];
+					pageInfoResponse.query.pages.forEach(function(page) {
+						if ( page.pageprops && page.pageprops.displaytitle) {
+							displaytitles[page.title] = page.pageprops.displaytitle;
+						} else {
+							displaytitles[page.title] = page.title;
+						}
+					});
+
 					connections.pages.forEach(function(page) {
-						if(missingPages.includes(page.title)) {
+						page.displaytitle = displaytitles[page.title];
+						if (missingPages.includes(page.title)) {
 							page.isMissing = true;
 						}
 					});
@@ -73,6 +83,8 @@ module.ApiPageConnectionRepo = ( function ( mw, ApiConnectionsBuilder ) {
 		return new mw.Api().get({
 			action: 'query',
 			titles: pageNodes.map(page => page.title),
+
+			prop: [ 'pageprops' ],
 
 			format: 'json',
 			redirects: 'true'

--- a/resources/js/Network.js
+++ b/resources/js/Network.js
@@ -6,12 +6,13 @@ module.Network = (function (vis, NetworkData) {
 	 * @param {module.ApiPageConnectionRepo} pageConnectionRepo
 	 * @param {module.PageBlacklist} pageBlacklist
 	 * @param {object} options
+	 * @param {int} labelMaxLength
 	 */
-	let Network = function(divId, pageConnectionRepo, pageBlacklist, options) {
+	let Network = function(divId, pageConnectionRepo, pageBlacklist, options, labelMaxLength ) {
 		this._pageConnectionRepo = pageConnectionRepo;
 
 		this._options = options;
-		this._data = new NetworkData(pageBlacklist);
+		this._data = new NetworkData(pageBlacklist, labelMaxLength);
 		this._network = this._newNetwork(divId);
 
 		this._bindEvents();
@@ -26,7 +27,7 @@ module.Network = (function (vis, NetworkData) {
 
 		promise.then(
 			connections => {
-				this._data.addPages(connections.pages);
+				this._data.addPages(connections.pages, this._maxLabelLength);
 				this._data.addLinks(connections.links);
 			}
 		);

--- a/resources/js/Network.js
+++ b/resources/js/Network.js
@@ -7,22 +7,18 @@ module.Network = (function (vis, NetworkData) {
 	 * @param {module.PageBlacklist} pageBlacklist
 	 * @param {object} options
 	 * @param {int} labelMaxLength
-	 * @param {boolean} enableDisplayTitle
 	 */
 	let Network = function(
 		divId,
 		pageConnectionRepo,
 		pageBlacklist,
 		options,
-		labelMaxLength,
-		enableDisplayTitle
+		labelMaxLength
 	) {
 		this._pageConnectionRepo = pageConnectionRepo;
-
-		this._options = options;
 		this._data = new NetworkData(pageBlacklist, labelMaxLength);
+		this._options = options;
 		this._network = this._newNetwork(divId);
-		this._enableDisplayTitle = enableDisplayTitle;
 
 		this._bindEvents();
 	};
@@ -32,7 +28,7 @@ module.Network = (function (vis, NetworkData) {
 	 * @return {Promise}
 	 */
 	Network.prototype.showPages = function(pageNames) {
-		let promise = this._pageConnectionRepo.addConnections(pageNames, this._enableDisplayTitle);
+		let promise = this._pageConnectionRepo.addConnections(pageNames);
 
 		promise.then(
 			connections => {

--- a/resources/js/Network.js
+++ b/resources/js/Network.js
@@ -7,13 +7,22 @@ module.Network = (function (vis, NetworkData) {
 	 * @param {module.PageBlacklist} pageBlacklist
 	 * @param {object} options
 	 * @param {int} labelMaxLength
+	 * @param {boolean} enableDisplayTitle
 	 */
-	let Network = function(divId, pageConnectionRepo, pageBlacklist, options, labelMaxLength ) {
+	let Network = function(
+		divId,
+		pageConnectionRepo,
+		pageBlacklist,
+		options,
+		labelMaxLength,
+		enableDisplayTitle
+	) {
 		this._pageConnectionRepo = pageConnectionRepo;
 
 		this._options = options;
 		this._data = new NetworkData(pageBlacklist, labelMaxLength);
 		this._network = this._newNetwork(divId);
+		this._enableDisplayTitle = enableDisplayTitle;
 
 		this._bindEvents();
 	};
@@ -23,7 +32,7 @@ module.Network = (function (vis, NetworkData) {
 	 * @return {Promise}
 	 */
 	Network.prototype.showPages = function(pageNames) {
-		let promise = this._pageConnectionRepo.addConnections(pageNames);
+		let promise = this._pageConnectionRepo.addConnections(pageNames, this._enableDisplayTitle);
 
 		promise.then(
 			connections => {

--- a/resources/js/Network.js
+++ b/resources/js/Network.js
@@ -27,7 +27,7 @@ module.Network = (function (vis, NetworkData) {
 
 		promise.then(
 			connections => {
-				this._data.addPages(connections.pages, this._maxLabelLength);
+				this._data.addPages(connections.pages);
 				this._data.addLinks(connections.links);
 			}
 		);

--- a/resources/js/NetworkData.js
+++ b/resources/js/NetworkData.js
@@ -17,18 +17,23 @@ module.NetworkData = ( function ( vis, mw ) {
 			pages
 				.filter(page => this._pageTitleIsAllowed(page.title))
 				.map(function(page) {
-					let label = page.displaytitle;
-					if (maxlength > 0 && label.length > maxlength) {
-						label = label.slice(0, maxlength) + '\u2026';
+					if (maxlength > 0 && page.displayTitle.length > maxlength) {
+						page.label = page.displayTitle.slice(0, maxlength) + '\u2026';
+					} else {
+						page.label = page.displayTitle;
 					}
-					let title = page.displaytitle;
-					if (page.title !== page.displaytitle) {
-						title += ' <i>(' + page.title + ')</i>';
+					if (page.title !== page.displayTitle) {
+						page.tooltip = page.displayTitle + ' <i>(' + page.title + ')</i>';
+					} else {
+						page.tooltip = page.displayTitle;
 					}
+					return page;
+				})
+				.map(function(page) {
 					let node = {
 						id: page.title,
-						label: label,
-						title: title,
+						label: page.label,
+						title: page.tooltip,
 
 						getUrl: function() {
 							let title = mw.Title.newFromText(page.title, page.ns);

--- a/resources/js/NetworkData.js
+++ b/resources/js/NetworkData.js
@@ -4,20 +4,31 @@
 module.NetworkData = ( function ( vis, mw ) {
 	"use strict"
 
-	let NetworkData = function(pageBlacklist) {
+	let NetworkData = function(pageBlacklist, labelMaxLength) {
 		this.nodes = new vis.DataSet();
 		this.edges = new vis.DataSet();
 		this._pageBlacklist = pageBlacklist;
+		this._labelMaxLength = labelMaxLength;
 	};
 
 	NetworkData.prototype.addPages = function(pages) {
+		var maxlength = this._labelMaxLength;
 		this.nodes.update(
 			pages
 				.filter(page => this._pageTitleIsAllowed(page.title))
 				.map(function(page) {
+					let label = page.displaytitle;
+					if (label.length > maxlength) {
+						label = label.slice(0, maxlength) + '\u2026';
+					}
+					let title = page.displaytitle;
+					if (page.title !== page.displaytitle) {
+						title += ' <i>(' + page.title + ')</i>';
+					}
 					let node = {
 						id: page.title,
-						label: page.displaytitle,
+						label: label,
+						title: title,
 
 						getUrl: function() {
 							let title = mw.Title.newFromText(page.title, page.ns);

--- a/resources/js/NetworkData.js
+++ b/resources/js/NetworkData.js
@@ -17,7 +17,7 @@ module.NetworkData = ( function ( vis, mw ) {
 				.map(function(page) {
 					let node = {
 						id: page.title,
-						label: page.title,
+						label: page.displaytitle,
 
 						getUrl: function() {
 							let title = mw.Title.newFromText(page.title, page.ns);

--- a/resources/js/NetworkData.js
+++ b/resources/js/NetworkData.js
@@ -18,7 +18,7 @@ module.NetworkData = ( function ( vis, mw ) {
 				.filter(page => this._pageTitleIsAllowed(page.title))
 				.map(function(page) {
 					let label = page.displaytitle;
-					if (label.length > maxlength) {
+					if (maxlength > 0 && label.length > maxlength) {
 						label = label.slice(0, maxlength) + '\u2026';
 					}
 					let title = page.displaytitle;

--- a/resources/js/index.js
+++ b/resources/js/index.js
@@ -15,7 +15,8 @@
 					mw.config.get('networkExcludeTalkPages')
 				),
 				$this.data('options'),
-				$this.data('labelmaxlength')
+				$this.data('labelmaxlength'),
+				$this.data('enabledisplaytitle')
 			);
 
 			network.showPages($this.data('pages')).then(function() {

--- a/resources/js/index.js
+++ b/resources/js/index.js
@@ -8,15 +8,14 @@
 
 			let network = new netw.Network(
 				$this.attr('id'),
-				new netw.ApiPageConnectionRepo(),
+				new netw.ApiPageConnectionRepo($this.data('enabledisplaytitle')),
 				new netw.PageBlacklist(
 					$this.data('exclude'),
 					mw.config.get('networkExcludedNamespaces'),
 					mw.config.get('networkExcludeTalkPages')
 				),
 				$this.data('options'),
-				$this.data('labelmaxlength'),
-				$this.data('enabledisplaytitle')
+				$this.data('labelmaxlength')
 			);
 
 			network.showPages($this.data('pages')).then(function() {

--- a/resources/js/index.js
+++ b/resources/js/index.js
@@ -14,7 +14,8 @@
 					mw.config.get('networkExcludedNamespaces'),
 					mw.config.get('networkExcludeTalkPages')
 				),
-				$this.data('options')
+				$this.data('options'),
+				$this.data('labelmaxlength')
 			);
 
 			network.showPages($this.data('pages')).then(function() {

--- a/src/EntryPoints/NetworkFunction.php
+++ b/src/EntryPoints/NetworkFunction.php
@@ -33,8 +33,8 @@ class NetworkFunction {
 
 		$requestModel = new RequestModel();
 		$requestModel->functionArguments = $arguments;
-		$requestModel->defaultLabelMaxLength = (int)$GLOBALS['wgPageNetworkDefaultLabelMaxLength'];
 		$requestModel->defaultEnableDisplayTitle = (bool)$GLOBALS['wgPageNetworkDefaultEnableDisplayTitle'];
+		$requestModel->defaultLabelMaxLength = (int)$GLOBALS['wgPageNetworkDefaultLabelMaxLength'];
 
 		/**
 		 * @psalm-suppress PossiblyNullReference

--- a/src/EntryPoints/NetworkFunction.php
+++ b/src/EntryPoints/NetworkFunction.php
@@ -34,6 +34,7 @@ class NetworkFunction {
 		$requestModel = new RequestModel();
 		$requestModel->functionArguments = $arguments;
 		$requestModel->defaultLabelMaxLength = (int)$GLOBALS['wgPageNetworkDefaultLabelMaxLength'];
+		$requestModel->defaultEnableDisplayTitle = (bool)$GLOBALS['wgPageNetworkDefaultEnableDisplayTitle'];
 
 		/**
 		 * @psalm-suppress PossiblyNullReference

--- a/src/EntryPoints/NetworkFunction.php
+++ b/src/EntryPoints/NetworkFunction.php
@@ -33,6 +33,7 @@ class NetworkFunction {
 
 		$requestModel = new RequestModel();
 		$requestModel->functionArguments = $arguments;
+		$requestModel->defaultLabelMaxLength = (int)$GLOBALS['wgPageNetworkDefaultLabelMaxLength'];
 
 		/**
 		 * @psalm-suppress PossiblyNullReference

--- a/src/NetworkFunction/NetworkUseCase.php
+++ b/src/NetworkFunction/NetworkUseCase.php
@@ -28,6 +28,7 @@ class NetworkUseCase {
 		$response->cssClass = $this->getCssClass( $keyValuePairs );
 		$response->excludedPages = $this->getExcludedPages( $keyValuePairs );
 		$response->visJsOptions = $this->getVisJsOptions( $keyValuePairs );
+		$response->labelMaxLength = $this->getLabelMaxLength( $keyValuePairs, $request->defaultLabelMaxLength );
 
 		$this->presenter->showGraph( $response );
 	}
@@ -137,4 +138,12 @@ class NetworkUseCase {
 		return $this->pagesStringToArray( $arguments['exclude'] ?? '', ';' );
 	}
 
+	/**
+	 * @param string[] $arguments
+	 * @param int $defaultLabelMaxLength
+	 * @return int
+	 */
+	private function getLabelMaxLength(array $arguments, $defaultLabelMaxLength ): int {
+		return isset( $arguments['labelMaxLength'] ) ? (int)$arguments['labelMaxLength'] : $defaultLabelMaxLength;
+	}
 }

--- a/src/NetworkFunction/NetworkUseCase.php
+++ b/src/NetworkFunction/NetworkUseCase.php
@@ -29,6 +29,7 @@ class NetworkUseCase {
 		$response->excludedPages = $this->getExcludedPages( $keyValuePairs );
 		$response->visJsOptions = $this->getVisJsOptions( $keyValuePairs );
 		$response->labelMaxLength = $this->getLabelMaxLength( $keyValuePairs, $request->defaultLabelMaxLength );
+		$response->enableDisplayTitle = $this->getEnableDisplayTitle( $keyValuePairs, $request->defaultEnableDisplayTitle );
 
 		$this->presenter->showGraph( $response );
 	}
@@ -145,5 +146,16 @@ class NetworkUseCase {
 	 */
 	private function getLabelMaxLength(array $arguments, $defaultLabelMaxLength ): int {
 		return isset( $arguments['labelMaxLength'] ) ? (int)$arguments['labelMaxLength'] : $defaultLabelMaxLength;
+	}
+
+	/**
+	 * @param string[] $arguments
+	 * @param int $defaultLabelMaxLength
+	 * @return bool
+	 */
+	private function getEnableDisplayTitle(array $arguments, $defaultEnableDisplayTitle ): bool {
+		return isset( $arguments['enableDisplayTitle'] )
+			? filter_var( $arguments['enableDisplayTitle'], FILTER_VALIDATE_BOOLEAN )
+			: $defaultEnableDisplayTitle;
 	}
 }

--- a/src/NetworkFunction/NetworkUseCase.php
+++ b/src/NetworkFunction/NetworkUseCase.php
@@ -28,8 +28,8 @@ class NetworkUseCase {
 		$response->cssClass = $this->getCssClass( $keyValuePairs );
 		$response->excludedPages = $this->getExcludedPages( $keyValuePairs );
 		$response->visJsOptions = $this->getVisJsOptions( $keyValuePairs );
-		$response->labelMaxLength = $this->getLabelMaxLength( $keyValuePairs, $request->defaultLabelMaxLength );
 		$response->enableDisplayTitle = $this->getEnableDisplayTitle( $keyValuePairs, $request->defaultEnableDisplayTitle );
+		$response->labelMaxLength = $this->getLabelMaxLength( $keyValuePairs, $request->defaultLabelMaxLength );
 
 		$this->presenter->showGraph( $response );
 	}

--- a/src/NetworkFunction/NetworkUseCase.php
+++ b/src/NetworkFunction/NetworkUseCase.php
@@ -141,15 +141,6 @@ class NetworkUseCase {
 
 	/**
 	 * @param string[] $arguments
-	 * @param int $defaultLabelMaxLength
-	 * @return int
-	 */
-	private function getLabelMaxLength(array $arguments, int $defaultLabelMaxLength ): int {
-		return isset( $arguments['labelMaxLength'] ) ? (int)$arguments['labelMaxLength'] : $defaultLabelMaxLength;
-	}
-
-	/**
-	 * @param string[] $arguments
 	 * @param bool $defaultEnableDisplayTitle
 	 * @return bool
 	 */
@@ -157,5 +148,14 @@ class NetworkUseCase {
 		return isset( $arguments['enableDisplayTitle'] )
 			? filter_var( $arguments['enableDisplayTitle'], FILTER_VALIDATE_BOOLEAN )
 			: $defaultEnableDisplayTitle;
+	}
+
+	/**
+	 * @param string[] $arguments
+	 * @param int $defaultLabelMaxLength
+	 * @return int
+	 */
+	private function getLabelMaxLength(array $arguments, int $defaultLabelMaxLength ): int {
+		return isset( $arguments['labelMaxLength'] ) ? (int)$arguments['labelMaxLength'] : $defaultLabelMaxLength;
 	}
 }

--- a/src/NetworkFunction/NetworkUseCase.php
+++ b/src/NetworkFunction/NetworkUseCase.php
@@ -144,16 +144,16 @@ class NetworkUseCase {
 	 * @param int $defaultLabelMaxLength
 	 * @return int
 	 */
-	private function getLabelMaxLength(array $arguments, $defaultLabelMaxLength ): int {
+	private function getLabelMaxLength(array $arguments, int $defaultLabelMaxLength ): int {
 		return isset( $arguments['labelMaxLength'] ) ? (int)$arguments['labelMaxLength'] : $defaultLabelMaxLength;
 	}
 
 	/**
 	 * @param string[] $arguments
-	 * @param int $defaultLabelMaxLength
+	 * @param bool $defaultEnableDisplayTitle
 	 * @return bool
 	 */
-	private function getEnableDisplayTitle(array $arguments, $defaultEnableDisplayTitle ): bool {
+	private function getEnableDisplayTitle(array $arguments, bool $defaultEnableDisplayTitle ): bool {
 		return isset( $arguments['enableDisplayTitle'] )
 			? filter_var( $arguments['enableDisplayTitle'], FILTER_VALIDATE_BOOLEAN )
 			: $defaultEnableDisplayTitle;

--- a/src/NetworkFunction/ParserFunctionNetworkPresenter.php
+++ b/src/NetworkFunction/ParserFunctionNetworkPresenter.php
@@ -25,8 +25,8 @@ class ParserFunctionNetworkPresenter implements NetworkPresenter {
 					'data-pages' => json_encode( $viewModel->pageNames ),
 					'data-exclude' => json_encode( $viewModel->excludedPages ),
 					'data-options' => json_encode( $viewModel->visJsOptions ),
-					'data-labelmaxlength' => json_encode( $viewModel->labelMaxLength ),
 					'data-enabledisplaytitle' => json_encode( $viewModel->enableDisplayTitle ),
+					'data-labelmaxlength' => json_encode( $viewModel->labelMaxLength ),
 				]
 			),
 			'noparse' => true,

--- a/src/NetworkFunction/ParserFunctionNetworkPresenter.php
+++ b/src/NetworkFunction/ParserFunctionNetworkPresenter.php
@@ -26,6 +26,7 @@ class ParserFunctionNetworkPresenter implements NetworkPresenter {
 					'data-exclude' => json_encode( $viewModel->excludedPages ),
 					'data-options' => json_encode( $viewModel->visJsOptions ),
 					'data-labelmaxlength' => json_encode( $viewModel->labelMaxLength ),
+					'data-enabledisplaytitle' => json_encode( $viewModel->enableDisplayTitle ),
 				]
 			),
 			'noparse' => true,

--- a/src/NetworkFunction/ParserFunctionNetworkPresenter.php
+++ b/src/NetworkFunction/ParserFunctionNetworkPresenter.php
@@ -25,6 +25,7 @@ class ParserFunctionNetworkPresenter implements NetworkPresenter {
 					'data-pages' => json_encode( $viewModel->pageNames ),
 					'data-exclude' => json_encode( $viewModel->excludedPages ),
 					'data-options' => json_encode( $viewModel->visJsOptions ),
+					'data-labelmaxlength' => json_encode( $viewModel->labelMaxLength ),
 				]
 			),
 			'noparse' => true,

--- a/src/NetworkFunction/RequestModel.php
+++ b/src/NetworkFunction/RequestModel.php
@@ -8,5 +8,6 @@ class RequestModel {
 
 	public /* string[] */ $functionArguments;
 	public /* string */ $renderingPageName;
+	public /* int */ $defaultLabelMaxLength;
 
 }

--- a/src/NetworkFunction/RequestModel.php
+++ b/src/NetworkFunction/RequestModel.php
@@ -8,7 +8,7 @@ class RequestModel {
 
 	public /* string[] */ $functionArguments;
 	public /* string */ $renderingPageName;
-	public /* int */ $defaultLabelMaxLength;
 	public /* bool */ $defaultEnableDisplayTitle;
+	public /* int */ $defaultLabelMaxLength;
 
 }

--- a/src/NetworkFunction/RequestModel.php
+++ b/src/NetworkFunction/RequestModel.php
@@ -9,5 +9,6 @@ class RequestModel {
 	public /* string[] */ $functionArguments;
 	public /* string */ $renderingPageName;
 	public /* int */ $defaultLabelMaxLength;
+	public /* bool */ $defaultEnableDisplayTitle;
 
 }

--- a/src/NetworkFunction/ResponseModel.php
+++ b/src/NetworkFunction/ResponseModel.php
@@ -9,8 +9,8 @@ class ResponseModel {
 	public /* string[] */ $pageNames;
 	public /* string */ $cssClass;
 	public /* string[] */ $excludedPages;
-	public /* int */ $labelMaxLength;
 	public /* bool */ $enableDisplayTitle;
+	public /* int */ $labelMaxLength;
 	public /* array */ $visJsOptions;
 
 }

--- a/src/NetworkFunction/ResponseModel.php
+++ b/src/NetworkFunction/ResponseModel.php
@@ -10,6 +10,7 @@ class ResponseModel {
 	public /* string */ $cssClass;
 	public /* string[] */ $excludedPages;
 	public /* int */ $labelMaxLength;
+	public /* bool */ $enableDisplayTitle;
 	public /* array */ $visJsOptions;
 
 }

--- a/src/NetworkFunction/ResponseModel.php
+++ b/src/NetworkFunction/ResponseModel.php
@@ -9,6 +9,7 @@ class ResponseModel {
 	public /* string[] */ $pageNames;
 	public /* string */ $cssClass;
 	public /* string[] */ $excludedPages;
+	public /* int */ $labelMaxLength;
 	public /* array */ $visJsOptions;
 
 }

--- a/tests/php/NetworkFunction/NetworkUseCaseTest.php
+++ b/tests/php/NetworkFunction/NetworkUseCaseTest.php
@@ -35,6 +35,8 @@ class NetworkUseCaseTest extends TestCase {
 
 		$request->renderingPageName = 'MyPage';
 		$request->functionArguments = [ '' ];
+		$request->defaultEnableDisplayTitle = true;
+		$request->defaultLabelMaxLength = 20;
 
 		return $request;
 	}
@@ -133,6 +135,48 @@ class NetworkUseCaseTest extends TestCase {
 		$this->assertSame(
 			[ 'too many pages' ],
 			$this->runAndReturnPresenter( $request )->getErrors()
+		);
+	}
+
+	public function testDefaultEnableDisplayTitle() {
+		$request = $this->newBasicRequestModel();
+
+		$this->assertSame(
+			$request->defaultEnableDisplayTitle,
+			true
+		);
+		$this->assertSame(
+			$this->runAndReturnPresenter( $request )->getResponseModel()->enableDisplayTitle,
+			true
+		);
+	}
+
+	public function testOverrideEnableDisplayTitleFalse() {
+		$request = $this->newBasicRequestModel();
+		$request->functionArguments = [ 'enableDisplayTitle = true' ];
+
+		$this->assertSame(
+			$request->defaultEnableDisplayTitle,
+			true
+		);
+		$this->assertSame(
+			$this->runAndReturnPresenter( $request )->getResponseModel()->enableDisplayTitle,
+			true
+		);
+	}
+
+
+	public function testOverrideEnableDisplayTitleTrue() {
+		$request = $this->newBasicRequestModel();
+		$request->functionArguments = [ 'enableDisplayTitle = false' ];
+
+		$this->assertSame(
+			$request->defaultEnableDisplayTitle,
+			true
+		);
+		$this->assertSame(
+			$this->runAndReturnPresenter( $request )->getResponseModel()->enableDisplayTitle,
+			false
 		);
 	}
 

--- a/tests/php/NetworkFunction/NetworkUseCaseTest.php
+++ b/tests/php/NetworkFunction/NetworkUseCaseTest.php
@@ -141,42 +141,36 @@ class NetworkUseCaseTest extends TestCase {
 	public function testDefaultEnableDisplayTitle() {
 		$request = $this->newBasicRequestModel();
 
-		$this->assertSame(
-			$request->defaultEnableDisplayTitle,
-			true
+		$this->assertTrue(
+			$request->defaultEnableDisplayTitle
 		);
-		$this->assertSame(
-			$this->runAndReturnPresenter( $request )->getResponseModel()->enableDisplayTitle,
-			true
+		$this->assertTrue(
+			$this->runAndReturnPresenter( $request )->getResponseModel()->enableDisplayTitle
 		);
 	}
-
-	public function testOverrideEnableDisplayTitleFalse() {
-		$request = $this->newBasicRequestModel();
-		$request->functionArguments = [ 'enableDisplayTitle = true' ];
-
-		$this->assertSame(
-			$request->defaultEnableDisplayTitle,
-			true
-		);
-		$this->assertSame(
-			$this->runAndReturnPresenter( $request )->getResponseModel()->enableDisplayTitle,
-			true
-		);
-	}
-
 
 	public function testOverrideEnableDisplayTitleTrue() {
 		$request = $this->newBasicRequestModel();
+		$request->functionArguments = [ 'enableDisplayTitle = true' ];
+
+		$this->assertTrue(
+			$request->defaultEnableDisplayTitle
+		);
+		$this->assertTrue(
+			$this->runAndReturnPresenter( $request )->getResponseModel()->enableDisplayTitle
+		);
+	}
+
+
+	public function testOverrideEnableDisplayTitleFalse() {
+		$request = $this->newBasicRequestModel();
 		$request->functionArguments = [ 'enableDisplayTitle = false' ];
 
-		$this->assertSame(
-			$request->defaultEnableDisplayTitle,
-			true
+		$this->assertTrue(
+			$request->defaultEnableDisplayTitle
 		);
-		$this->assertSame(
-			$this->runAndReturnPresenter( $request )->getResponseModel()->enableDisplayTitle,
-			false
+		$this->assertFalse(
+			$this->runAndReturnPresenter( $request )->getResponseModel()->enableDisplayTitle
 		);
 	}
 

--- a/tests/php/NetworkFunction/NetworkUseCaseTest.php
+++ b/tests/php/NetworkFunction/NetworkUseCaseTest.php
@@ -142,9 +142,6 @@ class NetworkUseCaseTest extends TestCase {
 		$request = $this->newBasicRequestModel();
 
 		$this->assertTrue(
-			$request->defaultEnableDisplayTitle
-		);
-		$this->assertTrue(
 			$this->runAndReturnPresenter( $request )->getResponseModel()->enableDisplayTitle
 		);
 	}
@@ -153,9 +150,6 @@ class NetworkUseCaseTest extends TestCase {
 		$request = $this->newBasicRequestModel();
 		$request->functionArguments = [ 'enableDisplayTitle = true' ];
 
-		$this->assertTrue(
-			$request->defaultEnableDisplayTitle
-		);
 		$this->assertTrue(
 			$this->runAndReturnPresenter( $request )->getResponseModel()->enableDisplayTitle
 		);
@@ -166,9 +160,6 @@ class NetworkUseCaseTest extends TestCase {
 		$request = $this->newBasicRequestModel();
 		$request->functionArguments = [ 'enableDisplayTitle = false' ];
 
-		$this->assertTrue(
-			$request->defaultEnableDisplayTitle
-		);
 		$this->assertFalse(
 			$this->runAndReturnPresenter( $request )->getResponseModel()->enableDisplayTitle
 		);


### PR DESCRIPTION
This pull request adds support for the displaytitle page property to Network graphs. This addresses issue #17. It includes the following capabilities:

- Adds $wgPageNetworkDefaultEnableDisplayTitle configuration variable to allow use of display title to be enabled or disabled site-wide. Default value is true.
- Adds enableDisplayTitle boolean parameter to the #network parser function to allow display title to be enabled or disabled on a per graph basis.
- Adds a tooltip to nodes. When you hover over a node, the tooltip will contain the untruncated node label. If the node has a display title, the label will be the display title followed by the node title in italics in parentheses. If the node does not have a display title or display titles are disabled, the tooltip will be the node title.
- Add $wgPageNetworkDefaultLabelMaxLength configuration variable to limit the length of labels of nodes site-wide. If node labels are truncated, an ellipses (...) will be appended to the truncated node label. A value of zero will disable the length limit. Default value is 20.
- Add labelMaxLength integer parameter to the #network parser function to limit the length of labels of nodes on a per graph basis.