### PR TITLE
Move config to extension.json and add node groups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,11 @@ $wgPageNetworkOptions = [
 ];
 ```
 
-	private function registerEditApiModuleFallbacks() {
-	}
+Predefined groups exist to represent links to existing pages (group "bluelink")
+and links to missing pages (group "redilink"). Styling of those groups can be
+overridden site-wide using `$wgPageNetworkOptions` or per graph using the options
+parameter described below.
+
 Note: to change the width or height, use CSS, not the network options.
 
 **$wgPageNetworkExcludeTalkPages**
@@ -308,6 +311,9 @@ Under development
 * Added optional support for using display title for nodes' labels.
 * Added configurable maximum length for node labels.
 * Added tooltips to nodes.
+* Made styling of nodes representing links to existing pages and links to
+  missing pages configurable by adding vis.js groups named "bluelink" and
+  "redlink".
 
 ### Version 1.4.0
 

--- a/extension.json
+++ b/extension.json
@@ -22,7 +22,33 @@
 
 	"config": {
 		"PageNetworkOptions": {
-			"value": []
+			"value": {
+				"layout": {
+					"randomSeed": 42
+				},
+				"physics": {
+					"barnesHut": {
+						"gravitationalConstant": -5000,
+						"damping": 0.242
+					}
+				},
+				"groups": {
+					"redlink": {
+						"color": {
+							"background": "lightgrey",
+							"border": "grey",
+							"highlight": {
+								"background": "lightgrey",
+								"border": "grey"
+							}
+						},
+						"font": {
+							"color": "#ba0000"
+						}
+					}
+				}
+			},
+			"merge_strategy": "array_replace_recursive"
 		},
 		"PageNetworkExcludeTalkPages": {
 			"value": true

--- a/resources/js/NetworkData.js
+++ b/resources/js/NetworkData.js
@@ -42,17 +42,9 @@ module.NetworkData = ( function ( vis, mw ) {
 					}
 
 					if (page.isMissing) {
-						node.color = {
-							background: 'lightgrey',
-							border: 'grey',
-							highlight: {
-								background: 'lightgrey',
-								border: 'grey',
-							}
-						};
-						node.font = {
-							color: '#ba0000'
-						};
+						node.group = 'redlink';
+					} else {
+						node.group = 'bluelink';
 					}
 
 					return node;

--- a/src/NetworkFunction/NetworkUseCase.php
+++ b/src/NetworkFunction/NetworkUseCase.php
@@ -64,17 +64,6 @@ class NetworkUseCase {
 
 	private function getVisJsOptions( array $arguments ): array {
 		return array_replace_recursive(
-			[
-				'layout' => [
-					'randomSeed' => 42
-				],
-				'physics' => [
-					'barnesHut' => [
-						'gravitationalConstant' => -5000,
-						'damping' => 0.242
-					]
-				]
-			],
 			$this->visJsOptions,
 			json_decode( $arguments['options'] ?? '{}', true ) ?? []
 		);

--- a/tests/php/NetworkFunction/NetworkUseCaseTest.php
+++ b/tests/php/NetworkFunction/NetworkUseCaseTest.php
@@ -223,15 +223,6 @@ class NetworkUseCaseTest extends TestCase {
 
 		$this->assertSame(
 			[
-				'layout' => [
-					'randomSeed' => 42
-				],
-				'physics' => [
-					'barnesHut' => [
-						'gravitationalConstant' => -5000,
-						'damping' => 0.242
-					]
-				],
 				'nodes' => [
 					'shape' => 'box'
 				]

--- a/tests/php/NetworkFunction/NetworkUseCaseTest.php
+++ b/tests/php/NetworkFunction/NetworkUseCaseTest.php
@@ -208,23 +208,12 @@ class NetworkUseCaseTest extends TestCase {
 		$request->functionArguments = [ 'options={"nodes": {"shape": "box"}}' ];
 
 		$presenter = new SpyNetworkPresenter();
-		$defaultOptions = [
-			'nodes' => [
-				'shape' => 'circle',
-				'color' => [
-					'background' => 'red'
-				]
-			]
-		];
-		( new NetworkUseCase( $presenter, $defaultOptions ) )->run( $request );
+		( new NetworkUseCase( $presenter, [] ) )->run( $request );
 
 		$this->assertSame(
 			[
 				'nodes' => [
 					'shape' => 'box',
-					'color' => [
-						'background' => 'red'
-					]
 				]
 			],
 			$presenter->getResponseModel()->visJsOptions
@@ -249,20 +238,11 @@ class NetworkUseCaseTest extends TestCase {
 		$this->assertEquals(
 			[
 				'height' => '42%',
-				'layout' => [
-					'randomSeed' => 42
-				],
 				'nodes' => [
 					'color' => 'red',
 					'shape' => 'box',
 					'foo' => 'bar'
 				],
-				'physics' => [
-					'barnesHut' => [
-						'gravitationalConstant' => -5000,
-						'damping' => 0.242
-					]
-				]
 			],
 			$presenter->getResponseModel()->visJsOptions
 		);

--- a/tests/php/NetworkFunction/NetworkUseCaseTest.php
+++ b/tests/php/NetworkFunction/NetworkUseCaseTest.php
@@ -25,7 +25,18 @@ class NetworkUseCaseTest extends TestCase {
 	private function runAndReturnPresenter( RequestModel $requestModel ): SpyNetworkPresenter {
 		$presenter = new SpyNetworkPresenter();
 
-		( new NetworkUseCase( $presenter, [] ) )->run( $requestModel );
+		$visJsOptions = [
+			'layout' => [
+				'randomSeed' => 42
+			],
+			'physics' => [
+				'barnesHut' => [
+					'gravitationalConstant' => -5000,
+					'damping' => 0.242
+				]
+			]
+		];
+		( new NetworkUseCase( $presenter, $visJsOptions ) )->run( $requestModel );
 
 		return $presenter;
 	}
@@ -170,17 +181,7 @@ class NetworkUseCaseTest extends TestCase {
 		( new NetworkUseCase( $presenter, [] ) )->run( $this->newBasicRequestModel() );
 
 		$this->assertSame(
-			[
-				'layout' => [
-					'randomSeed' => 42
-				],
-				'physics' => [
-					'barnesHut' => [
-						'gravitationalConstant' => -5000,
-						'damping' => 0.242
-					]
-				]
-			],
+			[],
 			$presenter->getResponseModel()->visJsOptions
 		);
 	}
@@ -197,19 +198,7 @@ class NetworkUseCaseTest extends TestCase {
 		( new NetworkUseCase( $presenter, $setting ) )->run( $this->newBasicRequestModel() );
 
 		$this->assertEquals(
-			[
-				'height' => '42%',
-				'layout' => [
-					'randomSeed' => 42,
-					'foo' => 'bar'
-				],
-				'physics' => [
-					'barnesHut' => [
-						'gravitationalConstant' => -5000,
-						'damping' => 0.242
-					]
-				]
-			],
+			$setting,
 			$presenter->getResponseModel()->visJsOptions
 		);
 	}
@@ -219,12 +208,23 @@ class NetworkUseCaseTest extends TestCase {
 		$request->functionArguments = [ 'options={"nodes": {"shape": "box"}}' ];
 
 		$presenter = new SpyNetworkPresenter();
-		( new NetworkUseCase( $presenter, [] ) )->run( $request );
+		$defaultOptions = [
+			'nodes' => [
+				'shape' => 'circle',
+				'color' => [
+					'background' => 'red'
+				]
+			]
+		];
+		( new NetworkUseCase( $presenter, $defaultOptions ) )->run( $request );
 
 		$this->assertSame(
 			[
 				'nodes' => [
-					'shape' => 'box'
+					'shape' => 'box',
+					'color' => [
+						'background' => 'red'
+					]
 				]
 			],
 			$presenter->getResponseModel()->visJsOptions


### PR DESCRIPTION
Prior to this change, the look of missing nodes and the physics of the graph were hard-coded and impossible to change with configuration. This change moves the configuration to extension.json and adds a "bluelink" and "redlink" node group. This allows configuration to be overriden by the options parameter and, ultimately (once [a bug](https://gerrit.wikimedia.org/r/c/mediawiki/core/+/693615) is fixed in MediaWiki core with the behavior of the array_replace_recursive merge strategy), with the $wgPageNetworkOptions configuation variable. Note that the latter will work to add new options but currently not to modify existing options.