### PR TITLE
Add support for title icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ or group options as (excerpted from the full options):
 }
 ```
 
+If the [Title Icon](https://mediawiki.org/wiki/Extension:Title_Icon) extension is installed and a page rendered in the
+graph has an OOUI or file type title icon defined and the node shape is set to "image", the title icon will be used for
+that node's icon.
+
 ### Configuration
 
 The default value of all parameters can be changed by placing configuration in "LocalSettings.php".

--- a/resources/js/NetworkData.js
+++ b/resources/js/NetworkData.js
@@ -52,6 +52,9 @@ module.NetworkData = ( function ( vis, mw ) {
 						node.group = 'bluelink';
 					}
 
+					if (page.image !== undefined) {
+						node.image = page.image;
+					}
 					return node;
 				})
 		);

--- a/src/EntryPoints/NetworkFunction.php
+++ b/src/EntryPoints/NetworkFunction.php
@@ -8,7 +8,6 @@ use MediaWiki\Extension\Network\Extension;
 use MediaWiki\Extension\Network\NetworkFunction\NetworkConfig;
 use MediaWiki\Extension\Network\NetworkFunction\NetworkPresenter;
 use MediaWiki\Extension\Network\NetworkFunction\NetworkUseCase;
-use MediaWiki\Extension\Network\NetworkFunction\ParserFunctionNetworkPresenter;
 use MediaWiki\Extension\Network\NetworkFunction\RequestModel;
 use Parser;
 

--- a/src/NetworkFunction/NetworkConfig.php
+++ b/src/NetworkFunction/NetworkConfig.php
@@ -4,6 +4,8 @@ declare( strict_types = 1 );
 
 namespace MediaWiki\Extension\Network\NetworkFunction;
 
+use MediaWiki\MediaWikiServices;
+
 class NetworkConfig {
 	/**
 	 * @var array
@@ -31,11 +33,12 @@ class NetworkConfig {
 	private $labelMaxLength;
 
 	public function __construct() {
-		$this->options = $GLOBALS['wgPageNetworkOptions'];
-		$this->excludeTalkPages = (bool)$GLOBALS['wgPageNetworkExcludeTalkPages'];
-		$this->excludedNamespaces = array_map( 'strval', $GLOBALS['wgPageNetworkExcludedNamespaces'] );
-		$this->enableDisplayTitle = (bool)$GLOBALS['wgPageNetworkEnableDisplayTitle'];
-		$this->labelMaxLength = (int)$GLOBALS['wgPageNetworkLabelMaxLength'];
+		$config = MediaWikiServices::getInstance()->getMainConfig();
+		$this->options = $config->get( 'PageNetworkOptions' );
+		$this->excludeTalkPages = (bool)$config->get( 'PageNetworkExcludeTalkPages' );
+		$this->excludedNamespaces = array_map( 'strval', $config->get( 'PageNetworkExcludedNamespaces' ) );
+		$this->enableDisplayTitle = (bool)$config->get( 'PageNetworkEnableDisplayTitle' );
+		$this->labelMaxLength = (int)$config->get( 'PageNetworkLabelMaxLength' );
 	}
 
 	public function getOptions(): array {

--- a/src/NetworkFunction/ParserFunctionNetworkPresenter.php
+++ b/src/NetworkFunction/ParserFunctionNetworkPresenter.php
@@ -4,8 +4,6 @@ declare( strict_types = 1 );
 
 namespace MediaWiki\Extension\Network\NetworkFunction;
 
-use Html;
-
 class ParserFunctionNetworkPresenter extends AbstractNetworkPresenter {
 
 	/**

--- a/tests/php/NetworkFunction/NetworkUseCaseTest.php
+++ b/tests/php/NetworkFunction/NetworkUseCaseTest.php
@@ -7,8 +7,6 @@ namespace MediaWiki\Extension\Network\Tests\NetworkFunction;
 use MediaWiki\Extension\Network\NetworkFunction\NetworkUseCase;
 use MediaWiki\Extension\Network\NetworkFunction\RequestModel;
 use PHPUnit\Framework\TestCase;
-use ReflectionClass;
-use Wikimedia\TestingAccessWrapper;
 
 /**
  * @covers \MediaWiki\Extension\Network\NetworkFunction\NetworkUseCase

--- a/tests/php/NetworkFunctionIntegrationTest.php
+++ b/tests/php/NetworkFunctionIntegrationTest.php
@@ -17,14 +17,14 @@ class NetworkFunctionIntegrationTest extends TestCase {
 	}
 
 	public function testWhenThereAreNoParameters_contextPageIsUsed() {
-		$this->assertStringContainsString(
+		$this->assertContains(
 			'data-pages="[&quot;ContextPageTitle&quot;]"',
 			$this->parse( '{{#network:}}' )
 		);
 	}
 
 	public function testOptionsParameters() {
-		$this->assertStringContainsString(
+		$this->assertContains(
 			'&quot;shape&quot;:&quot;tomato&quot;',
 			$this->parse( '{{#network:options={"nodes": {"shape": "tomato"} } }}' )
 		);

--- a/tests/php/NetworkFunctionIntegrationTest.php
+++ b/tests/php/NetworkFunctionIntegrationTest.php
@@ -17,14 +17,14 @@ class NetworkFunctionIntegrationTest extends TestCase {
 	}
 
 	public function testWhenThereAreNoParameters_contextPageIsUsed() {
-		$this->assertContains(
+		$this->assertStringContainsString(
 			'data-pages="[&quot;ContextPageTitle&quot;]"',
 			$this->parse( '{{#network:}}' )
 		);
 	}
 
 	public function testOptionsParameters() {
-		$this->assertContains(
+		$this->assertStringContainsString(
 			'&quot;shape&quot;:&quot;tomato&quot;',
 			$this->parse( '{{#network:options={"nodes": {"shape": "tomato"} } }}' )
 		);


### PR DESCRIPTION
* supports OOUI icons specified in {{#titleicon_ooui:...}} and file icons specified in {{#titleicon_file:...}} or [[Title Icon::...]]
* does not require the TitleIcon extension to be installed (although it will obviously only render title icons if it is installed)