### PR TITLE
Get title icons using TitleIcon API

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,10 @@ or group options as (excerpted from the full options):
 }
 ```
 
-If the [Title Icon](https://mediawiki.org/wiki/Extension:Title_Icon) extension is installed and a page rendered in the
-graph has a title icon defined, the title icon will be used for that node's icon.
+If version 5.1 or later of the [Title Icon](https://mediawiki.org/wiki/Extension:Title_Icon) extension is installed and
+a page rendered in the graph has at least one title icon defined, one of those title icons will be used for that node's
+icon. If there are multiple title icons defined for the page, one will be selected in the order in which they were
+parsed on the page.
 
 ### Configuration
 

--- a/resources/js/ApiPageConnectionRepo.js
+++ b/resources/js/ApiPageConnectionRepo.js
@@ -152,7 +152,7 @@ module.ApiPageConnectionRepo = ( function ( mw, ApiConnectionsBuilder ) {
 				let fileIcons = [];
 				let fileSearch = [];
 				pages.forEach(function(page) {
-					if (page.titleicons && page.titleicons) {
+					if (page.titleicons) {
 						try {
 							let icons = JSON.parse(page.titleicons);
 							for (let index in icons) {

--- a/resources/js/ApiPageConnectionRepo.js
+++ b/resources/js/ApiPageConnectionRepo.js
@@ -107,7 +107,7 @@ module.ApiPageConnectionRepo = ( function ( mw, ApiConnectionsBuilder ) {
 			redirects: 'true'
 		}
 		if (this._enableDisplayTitle) {
-			parameters.prop = [ 'pageprops' ];
+			parameters.prop = [ 'pageprops', 'titleicons' ];
 		}
 
 		return new mw.Api().get(parameters);
@@ -152,9 +152,9 @@ module.ApiPageConnectionRepo = ( function ( mw, ApiConnectionsBuilder ) {
 				let fileIcons = [];
 				let fileSearch = [];
 				pages.forEach(function(page) {
-					if (page.pageprops && page.pageprops.titleicons) {
+					if (page.titleicons && page.titleicons) {
 						try {
-							let icons = JSON.parse(page.pageprops.titleicons);
+							let icons = JSON.parse(page.titleicons);
 							for (let index in icons) {
 								let icon = icons[index]
 								if (icon.type === 'ooui') {
@@ -181,18 +181,20 @@ module.ApiPageConnectionRepo = ( function ( mw, ApiConnectionsBuilder ) {
 				}
 				this._queryFileUrls(files)
 					.done(function(imageInfoResponse) {
-						var filePages = Object.values(imageInfoResponse.query.pages);
-						let fileUrls = [];
-						filePages.forEach(function(filePage) {
-							if (filePage.imageInfo !== undefined
-								&& filePage.imageInfo[0] !== undefined
-								&& filePage.imageInfo[0].url !== undefined) {
-								fileUrls[filePage.title] = filePage.imageinfo[0].url;
-							}
-						})
+						if (imageInfoResponse.query && imageInfoResponse.query.pages) {
+							let fileUrls = [];
+							var filePages = Object.values(imageInfoResponse.query.pages);
+							filePages.forEach(function(filePage) {
+								if (filePage.imageInfo !== undefined
+									&& filePage.imageInfo[0] !== undefined
+									&& filePage.imageInfo[0].url !== undefined) {
+									fileUrls[filePage.title] = filePage.imageinfo[0].url;
+								}
+							})
 
-						for (let page in fileIcons) {
-							images[page] = fileUrls[fileIcons[page]];
+							for (let page in fileIcons) {
+								images[page] = fileUrls[fileIcons[page]];
+							}
 						}
 
 						resolve({'images': images, 'text': text});

--- a/resources/js/ApiPageConnectionRepo.js
+++ b/resources/js/ApiPageConnectionRepo.js
@@ -103,11 +103,13 @@ module.ApiPageConnectionRepo = ( function ( mw, ApiConnectionsBuilder ) {
 			action: 'query',
 			titles: titles,
 
+			prop: ['titleicons'],
+
 			format: 'json',
 			redirects: 'true'
 		}
 		if (this._enableDisplayTitle) {
-			parameters.prop = [ 'pageprops', 'titleicons' ];
+			parameters.prop.concat('pageprops');
 		}
 
 		return new mw.Api().get(parameters);

--- a/resources/js/ApiPageConnectionRepo.js
+++ b/resources/js/ApiPageConnectionRepo.js
@@ -109,7 +109,7 @@ module.ApiPageConnectionRepo = ( function ( mw, ApiConnectionsBuilder ) {
 			redirects: 'true'
 		}
 		if (this._enableDisplayTitle) {
-			parameters.prop.concat('pageprops');
+			parameters.prop.push('pageprops');
 		}
 
 		return new mw.Api().get(parameters);

--- a/resources/js/ApiPageConnectionRepo.js
+++ b/resources/js/ApiPageConnectionRepo.js
@@ -187,9 +187,9 @@ module.ApiPageConnectionRepo = ( function ( mw, ApiConnectionsBuilder ) {
 							let fileUrls = [];
 							var filePages = Object.values(imageInfoResponse.query.pages);
 							filePages.forEach(function(filePage) {
-								if (filePage.imageInfo !== undefined
-									&& filePage.imageInfo[0] !== undefined
-									&& filePage.imageInfo[0].url !== undefined) {
+								if (filePage.imageinfo !== undefined
+									&& filePage.imageinfo[0] !== undefined
+									&& filePage.imageinfo[0].url !== undefined) {
 									fileUrls[filePage.title] = filePage.imageinfo[0].url;
 								}
 							})

--- a/resources/js/ApiPageConnectionRepo.js
+++ b/resources/js/ApiPageConnectionRepo.js
@@ -64,9 +64,9 @@ module.ApiPageConnectionRepo = ( function ( mw, ApiConnectionsBuilder ) {
 										page.displayTitle = displayTitles[page.title];
 									}
 
-									if (titleIcons.images[page.title] !== undefined) {
+									if (titleIcons.images[page.title]) {
 										page.image = titleIcons.images[page.title];
-									} else if (titleIcons.text[page.title] !== undefined) {
+									} else if (titleIcons.text[page.title]) {
 										page.text = titleIcons.text[page.title];
 									}
 								});
@@ -187,9 +187,7 @@ module.ApiPageConnectionRepo = ( function ( mw, ApiConnectionsBuilder ) {
 							let fileUrls = [];
 							var filePages = Object.values(imageInfoResponse.query.pages);
 							filePages.forEach(function(filePage) {
-								if (filePage.imageinfo !== undefined
-									&& filePage.imageinfo[0] !== undefined
-									&& filePage.imageinfo[0].url !== undefined) {
+								if (filePage.imageinfo && filePage.imageinfo[0] && filePage.imageinfo[0].url) {
 									fileUrls[filePage.title] = filePage.imageinfo[0].url;
 								}
 							})

--- a/resources/js/NetworkData.js
+++ b/resources/js/NetworkData.js
@@ -52,12 +52,12 @@ module.NetworkData = ( function ( vis, mw ) {
 						node.group = 'bluelink';
 					}
 
-					if (page.image !== undefined) {
+					if (page.image) {
 						node.image = page.image;
 						node.shape = 'image';
 					}
 
-					if (page.text !== undefined) {
+					if (page.text) {
 						let txt = document.createElement("textarea");
 						txt.innerHTML = page.text + '&nbsp;' + node.label;
 						node.label = txt.value;


### PR DESCRIPTION
Replace pageprops query, which only returns title icons for
the queried page, not category and namespace title icons.

Also add additional check for no imageInfo results.