### PR TITLE
Fixes issue 58 - redirects cause the visualization to break

### DIFF
--- a/resources/js/ApiConnectionsBuilder.js
+++ b/resources/js/ApiConnectionsBuilder.js
@@ -35,7 +35,8 @@ module.ApiConnectionsBuilder = ( function () {
 			.map(function(page) {
 				return {
 					title: page.title,
-					isExternal: page.external
+					isExternal: page.external,
+					isRedirect: page.isRedirect
 				};
 			});
 	};
@@ -44,14 +45,16 @@ module.ApiConnectionsBuilder = ( function () {
 		let pages = {};
 
 		centralPages.forEach(function(centralPage) {
-			pages[centralPage.title] = { title: centralPage.title, external: false };
+
+			// *** we assume is not a redirect
+			pages[centralPage.title] = { title: centralPage.title, external: false, isRedirect: false };
 
 			centralPage.outgoingLinks.forEach(
 				page => { pages[page.title] = { title: page.title, external: false } }
 			);
 
 			centralPage.incomingLinks.forEach(
-				page => { pages[page.title] = { title: page.title, external: false } }
+				page => { pages[page.title] = { title: page.title, external: false, isRedirect: ( 'redirect' in page ) } }
 			);
 
 			centralPage.externalLinks.forEach(

--- a/resources/js/ApiPageConnectionRepo.js
+++ b/resources/js/ApiPageConnectionRepo.js
@@ -47,21 +47,28 @@ module.ApiPageConnectionRepo = ( function ( mw, ApiConnectionsBuilder ) {
 						let pages = Object.values(pageInfoResponse.query.pages)
 
 						let missingPages = this._getMissingPages(pages)
-
+					
+						// @Attention!! this won't include the redirects
+						// (the redirects are at pageInfoResponse.query.redirects !)
+						// so connections.pages and pageInfoResponse.query.pages
+						// may differ
 						let displayTitles = this._getDisplayTitles(pages)
 
 						this._getTitleIcons(pages)
 							.then(function(titleIcons) {
 
 								connections.pages.forEach(function(page) {
+								
 									if (missingPages.includes(page.title)) {
 										page.isMissing = true;
 									}
 
 									if (page.isExternal) {
 										page.displayTitle = page.title;
-									} else {
+									} else if ( !page.isRedirect ) {
 										page.displayTitle = displayTitles[page.title];
+									} else {
+										page.displayTitle = page.title;
 									}
 
 									if (titleIcons.images[page.title]) {

--- a/resources/js/ApiPageConnectionRepo.js
+++ b/resources/js/ApiPageConnectionRepo.js
@@ -47,7 +47,7 @@ module.ApiPageConnectionRepo = ( function ( mw, ApiConnectionsBuilder ) {
 						let pages = Object.values(pageInfoResponse.query.pages)
 
 						let missingPages = this._getMissingPages(pages)
-					
+
 						// @Attention!! this won't include the redirects
 						// (the redirects are at pageInfoResponse.query.redirects !)
 						// so connections.pages and pageInfoResponse.query.pages
@@ -58,7 +58,6 @@ module.ApiPageConnectionRepo = ( function ( mw, ApiConnectionsBuilder ) {
 							.then(function(titleIcons) {
 
 								connections.pages.forEach(function(page) {
-								
 									if (missingPages.includes(page.title)) {
 										page.isMissing = true;
 									}

--- a/resources/js/NetworkData.js
+++ b/resources/js/NetworkData.js
@@ -16,7 +16,7 @@ module.NetworkData = ( function ( vis, mw ) {
 		this.nodes.update(
 			pages
 				.filter(page => this._pageTitleIsAllowed(page.title))
-				.map(function(page) {	
+				.map(function(page) {
 					if (maxlength > 0 && page.displayTitle.length > maxlength) {
 						page.label = page.displayTitle.slice(0, maxlength) + '\u2026';
 					} else {

--- a/resources/js/NetworkData.js
+++ b/resources/js/NetworkData.js
@@ -16,7 +16,7 @@ module.NetworkData = ( function ( vis, mw ) {
 		this.nodes.update(
 			pages
 				.filter(page => this._pageTitleIsAllowed(page.title))
-				.map(function(page) {
+				.map(function(page) {	
 					if (maxlength > 0 && page.displayTitle.length > maxlength) {
 						page.label = page.displayTitle.slice(0, maxlength) + '\u2026';
 					} else {
@@ -26,6 +26,9 @@ module.NetworkData = ( function ( vis, mw ) {
 						page.tooltip = page.displayTitle + ' <i>(' + page.title + ')</i>';
 					} else {
 						page.tooltip = page.displayTitle;
+					}
+					if ( page.isRedirect ) {
+						page.tooltip += ' <i>(redirect)</i>';
 					}
 					return page;
 				})


### PR DESCRIPTION
fixes https://github.com/ProfessionalWiki/Network/issues/58
see also https://github.com/ProfessionalWiki/Network/issues/69

the problem seems caused by an inconsistency between `connections.pages` and `pageInfoResponse.query.pages` (the map `displayTitles`  is filled with items from `pageInfoResponse.query.pages` but the latter does not contain the redirects (they are in a separated result key) so this line 
`
page.displayTitle = displayTitles[page.title];
`

triggers an error.
A `isRedirect` attribute is therefore added to` ApiConnectionsBuilder -> _buildPageMap` and used for the tooltip as well ( `NetworkData -> addPages` )

 