### PR TITLE
Update CI and bump minimum MW requirement to 1.39

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,22 +12,29 @@ on:
 jobs:
   test:
     name: "PHPUnit: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}"
+    continue-on-error: ${{ matrix.experimental }}
 
     strategy:
       matrix:
         include:
-          - mw: 'REL1_33'
-            php: 7.4
-          - mw: 'REL1_34'
-            php: 7.4
-          - mw: 'REL1_35'
-            php: 7.4
-          - mw: 'REL1_36'
-            php: 7.4
-          - mw: 'REL1_37'
-            php: 8.0
-          - mw: 'REL1_38'
+          - mw: 'REL1_39'
             php: 8.1
+            experimental: false
+          - mw: 'REL1_40'
+            php: 8.1
+            experimental: false
+          - mw: 'REL1_41'
+            php: 8.2
+            experimental: false
+          - mw: 'REL1_42'
+            php: 8.2
+            experimental: false
+          - mw: 'REL1_43'
+            php: 8.3
+            experimental: false
+          - mw: 'master'
+            php: 8.4
+            experimental: true
 
     runs-on: ubuntu-latest
 
@@ -46,26 +53,30 @@ jobs:
 
       - name: Cache MediaWiki
         id: cache-mediawiki
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             mediawiki
             !mediawiki/extensions/
             !mediawiki/vendor/
-          key: mw_${{ matrix.mw }}-php${{ matrix.php }}-v20
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}-v21
 
       - name: Cache Composer cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache
           key: composer-php${{ matrix.php }}
 
+      - uses: actions/checkout@v4
+        with:
+          path: EarlyCopy
+  
       - name: Install MediaWiki
         if: steps.cache-mediawiki.outputs.cache-hit != 'true'
         working-directory: ~
-        run: curl https://gist.githubusercontent.com/JeroenDeDauw/49a3858653ff4b5be7ec849019ede06c/raw/installMediaWiki.sh | bash -s ${{ matrix.mw }} Network
+        run: bash EarlyCopy/.github/workflows/installMediaWiki.sh ${{ matrix.mw }} Network
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           path: mediawiki/extensions/Network
 
@@ -76,7 +87,13 @@ jobs:
         run: php tests/phpunit/phpunit.php -c extensions/Network/phpunit.xml.dist
 
   static-analysis:
-    name: "Static Analysis"
+    name: "Static Analysis: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}"
+
+    strategy:
+      matrix:
+        include:
+          - mw: 'REL1_43'
+            php: '8.3'
 
     runs-on: ubuntu-latest
 
@@ -88,13 +105,13 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: ${{ matrix.php }}
           extensions: mbstring
-          tools: composer:v1, cs2pr
+          tools: composer, cs2pr
 
       - name: Cache MediaWiki
         id: cache-mediawiki
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             mediawiki
@@ -103,17 +120,21 @@ jobs:
           key: mediawiki-cache
 
       - name: Cache Composer cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache
-          key: composer-cache
+          key: composer_static_analysis
 
+      - uses: actions/checkout@v4
+        with:
+          path: EarlyCopy
+  
       - name: Install MediaWiki
         if: steps.cache-mediawiki.outputs.cache-hit != 'true'
         working-directory: ~
-        run: curl https://gist.githubusercontent.com/JeroenDeDauw/49a3858653ff4b5be7ec849019ede06c/raw/installMediaWiki.sh | bash -s REL1_34 Network
-
-      - uses: actions/checkout@v2
+        run: bash EarlyCopy/.github/workflows/installMediaWiki.sh ${{ matrix.mw }} Network
+  
+      - uses: actions/checkout@v4
         with:
           path: mediawiki/extensions/Network
 
@@ -125,3 +146,63 @@ jobs:
 
       - name: Psalm
         run: php vendor/bin/psalm
+
+  code-style:
+    name: "Code style: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}"
+
+    strategy:
+      matrix:
+        include:
+          - mw: 'REL1_43'
+            php: '8.3'
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: mediawiki/extensions/Network
+
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring, intl, php-ast
+          tools: composer
+
+      - name: Cache MediaWiki
+        id: cache-mediawiki
+        uses: actions/cache@v4
+        with:
+          path: |
+            mediawiki
+            !mediawiki/extensions/
+            !mediawiki/vendor/
+          key: mw_static_analysis
+
+      - name: Cache Composer cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: composer_static_analysis
+
+      - uses: actions/checkout@v4
+        with:
+          path: EarlyCopy
+
+      - name: Install MediaWiki
+        if: steps.cache-mediawiki.outputs.cache-hit != 'true'
+        working-directory: ~
+        run: bash EarlyCopy/.github/workflows/installMediaWiki.sh ${{ matrix.mw }} Network
+
+      - uses: actions/checkout@v4
+        with:
+          path: mediawiki/extensions/Network
+
+      - name: Composer allow-plugins
+        run: composer config --no-plugins allow-plugins.composer/installers true
+
+      - name: Composer install
+        run: composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
+
+      - run: vendor/bin/phpcs -p -s

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,13 @@ jobs:
       matrix:
         include:
           - mw: 'REL1_39'
-            php: 8.1
+            php: 7.4
             experimental: false
           - mw: 'REL1_40'
-            php: 8.1
+            php: 8.0
             experimental: false
           - mw: 'REL1_41'
-            php: 8.2
+            php: 8.1
             experimental: false
           - mw: 'REL1_42'
             php: 8.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: mbstring, intl
-          tools: composer:v1
+          tools: composer
 
       - name: Cache MediaWiki
         id: cache-mediawiki

--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -1,0 +1,45 @@
+#! /bin/bash
+
+set -ex
+
+MW_BRANCH=$1
+EXTENSION_NAME=$2
+
+wget "https://github.com/wikimedia/mediawiki/archive/refs/heads/$MW_BRANCH.tar.gz" -nv
+
+tar -zxf $MW_BRANCH.tar.gz
+mv mediawiki-$MW_BRANCH mediawiki
+
+cd mediawiki
+
+composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
+
+php maintenance/install.php \
+	--dbtype sqlite \
+	--dbuser root \
+	--dbname mw \
+	--dbpath "$(pwd)" \
+	--scriptpath="" \
+	--pass AdminPassword WikiName AdminUser
+
+echo 'error_reporting(E_ALL| E_STRICT);' >> LocalSettings.php
+echo 'ini_set("display_errors", 1);' >> LocalSettings.php
+echo '$wgShowExceptionDetails = true;' >> LocalSettings.php
+echo '$wgShowDBErrorBacktrace = true;' >> LocalSettings.php
+echo '$wgDevelopmentWarnings = true;' >> LocalSettings.php
+
+echo 'wfLoadExtension( "'$EXTENSION_NAME'" );' >> LocalSettings.php
+
+cat <<EOT >> composer.local.json
+{
+  	"require": {},
+	"extra": {
+		"merge-plugin": {
+			"merge-dev": true,
+			"include": [
+				"extensions/$EXTENSION_NAME/composer.json"
+			]
+		}
+	}
+}
+EOT

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 composer.lock
+.phpunit.result.cache

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ phpunit:
 	php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist
 
 phpcs:
-	cd ../.. && vendor/bin/phpcbf -p -s --standard=$(shell pwd)/phpcs.xml
+	cd ../.. && vendor/bin/phpcs -p -s --standard=$(shell pwd)/phpcs.xml
 
 psalm:
 	../../vendor/bin/psalm --config=psalm.xml

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,17 @@
-.PHONY: ci cs test phpunit psalm phpstan
+.PHONY: ci cs test phpunit phpcs psalm phpstan
 
-ci: phpstan phpunit psalm
-cs: phpstan psalm
+ci: test cs
+cs: phpcs phpstan psalm
 test: phpunit
 
 phpunit:
 	php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist
 
+phpcs:
+	cd ../.. && vendor/bin/phpcbf -p -s --standard=$(shell pwd)/phpcs.xml
+
 psalm:
-	./vendor/bin/psalm
+	../../vendor/bin/psalm --config=psalm.xml
 
 phpstan:
-	./vendor/bin/phpstan analyse -c phpstan.neon --no-progress
+	../../vendor/bin/phpstan analyse --configuration=phpstan.neon --memory-limit=2G

--- a/composer.json
+++ b/composer.json
@@ -43,11 +43,13 @@
 	},
 	"require-dev": {
 		"vimeo/psalm": "^5.17.0",
-		"phpstan/phpstan": "^2.0.2"
+		"phpstan/phpstan": "^2.0.2",
+		"mediawiki/mediawiki-codesniffer": "45.0.0"
 	},
 	"config": {
 		"allow-plugins": {
-			"composer/installers": true
+			"composer/installers": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -38,11 +38,11 @@
 		"source": "https://github.com/ProfessionalWiki/Network/issues"
 	},
 	"require": {
-		"php": ">=7.3",
+		"php": ">=7.4",
 		"composer/installers": "^2|^1.0.1"
 	},
 	"require-dev": {
-		"vimeo/psalm": "*",
+		"vimeo/psalm": "^4.30.0",
 		"phpstan/phpstan": "^2.0.2"
 	},
 	"config": {

--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
 	"name": "Network",
 
-	"version": "2.0.1",
+	"version": "3.0.0",
 
 	"author": [
 		"[https://www.entropywins.wtf/mediawiki Jeroen De Dauw]",
@@ -17,7 +17,7 @@
 	"type": "parserhook",
 
 	"requires": {
-		"MediaWiki": ">= 1.31.0"
+		"MediaWiki": ">= 1.39.0"
 	},
 
 	"config": {
@@ -108,8 +108,6 @@
 		"MediaWiki\\Extension\\Network\\Tests\\": "tests/php"
 	},
 
-	"callback": "MediaWiki\\Extension\\Network\\Extension::addMediaWiki131compat",
-
 	"Hooks": {
 		"ParserFirstCallInit": "MediaWiki\\Extension\\Network\\EntryPoints\\NetworkFunction::onParserFirstCallInit"
 	},
@@ -126,7 +124,7 @@
 	"ResourceModules": {
 		"ext.network": {
 			"dependencies": [
-				"mediawiki.api.edit",
+				"mediawiki.api",
 				"mediawiki.Title",
 				"mediawiki.jqueryMsg"
 			],

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<ruleset>
+	<file>src/</file>
+	<file>tests/php/</file>
+
+	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
+		<exclude name="Generic.Files.LineLength.TooLong" />
+	</rule>
+
+	<rule ref="Generic.Formatting.NoSpaceAfterCast" />
+	<rule ref="Generic.Metrics.CyclomaticComplexity" />
+	<rule ref="Generic.Metrics.NestingLevel" />
+	<rule ref="Squiz.Operators.ValidLogicalOperators" />
+</ruleset>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,3 +6,5 @@ parameters:
 	scanDirectories:
 		- ../../includes
 		- ../../vendor
+	bootstrapFiles:
+		- ../../includes/AutoLoader.php

--- a/psalm.xml
+++ b/psalm.xml
@@ -11,6 +11,7 @@
     </projectFiles>
 	<extraFiles>
 		<directory name="../../includes" />
+		<directory name="../../vendor/wikimedia" />
 	</extraFiles>
 	<issueHandlers>
 		<MissingPropertyType errorLevel="suppress" />

--- a/psalm.xml
+++ b/psalm.xml
@@ -16,6 +16,12 @@
 	<issueHandlers>
 		<MissingPropertyType errorLevel="suppress" />
 		<MissingClosureReturnType errorLevel="suppress" />
+		<MissingConstructor>
+			<errorLevel type="suppress">
+				<file name="src/NetworkFunction/RequestModel.php" />
+				<file name="src/NetworkFunction/ResponseModel.php" />
+			</errorLevel>
+		</MissingConstructor>
 		<MissingParamType>
 			<errorLevel type="suppress">
 				<file name="../../includes/specialpage/IncludableSpecialPage.php" />

--- a/psalm.xml
+++ b/psalm.xml
@@ -8,9 +8,6 @@
 >
     <projectFiles>
         <directory name="src" />
-        <ignoreFiles>
-            <directory name="vendor" />
-        </ignoreFiles>
     </projectFiles>
 	<extraFiles>
 		<directory name="../../includes" />

--- a/src/EntryPoints/SpecialNetwork.php
+++ b/src/EntryPoints/SpecialNetwork.php
@@ -25,7 +25,7 @@ class SpecialNetwork extends IncludableSpecialPage {
 		parent::__construct( 'Network' );
 	}
 
-	public function execute( $subPage ) : void {
+	public function execute( $subPage ): void {
 		$this->setHeaders();
 
 		$config = new NetworkConfig();
@@ -40,7 +40,7 @@ class SpecialNetwork extends IncludableSpecialPage {
 		}
 	}
 
-	private function parseParams( WebRequest $request, NetworkConfig $config ) : array {
+	private function parseParams( WebRequest $request, NetworkConfig $config ): array {
 		$params = [];
 
 		if ( $request->getCheck( 'pages' ) ) {
@@ -75,7 +75,7 @@ class SpecialNetwork extends IncludableSpecialPage {
 					FILTER_NULL_ON_FAILURE
 				);
 		} elseif ( $request->getCheck( 'pages' ) ) {
-			$params['enableDisplayTitle'] = $request->getCheck('enableDisplayTitle');
+			$params['enableDisplayTitle'] = $request->getCheck( 'enableDisplayTitle' );
 		} else {
 			$params['enableDisplayTitle'] = $config->getEnableDisplayTitle();
 		}
@@ -89,7 +89,7 @@ class SpecialNetwork extends IncludableSpecialPage {
 	 * @param array $params
 	 * @return string[]
 	 */
-	private function formatParams( array $params ) : array {
+	private function formatParams( array $params ): array {
 		$formattedParams = [];
 		if ( $params['pages'] === '' ) {
 			$formattedParams['pages'] = 'pages=' . Title::newMainPage()->getPrefixedText();
@@ -117,7 +117,7 @@ class SpecialNetwork extends IncludableSpecialPage {
 	 * @param NetworkConfig $config
 	 * @return string
 	 */
-	public function showGraph( array $arguments, NetworkConfig $config) : string {
+	public function showGraph( array $arguments, NetworkConfig $config ): string {
 		$output = $this->getOutput();
 		$output->addModules( [ 'ext.network' ] );
 		$output->addJsConfigVars( 'networkExcludeTalkPages', $config->getExcludeTalkPages() );
@@ -160,17 +160,17 @@ class SpecialNetwork extends IncludableSpecialPage {
 		) );
 	}
 
-	private function getNamespaces(NetworkConfig $config): array {
+	private function getNamespaces( NetworkConfig $config ): array {
 		$namespaces = MediaWikiServices::getInstance()->getContentLanguage()->getFormattedNamespaces();
 		$namespaces[0] = ( new Message( 'blanknamespace' ) )->plain();
 		return array_filter(
 			$namespaces,
-			function ( int $value ) use ( $config ) {
+			static function ( int $value ) use ( $config ) {
 				if ( $value < 0 ) {
 					return false;
 				}
 				if ( $config->getExcludeTalkPages() ) {
-					return !($value % 2);
+					return !( $value % 2 );
 				}
 				return true;
 			},

--- a/src/EntryPoints/SpecialNetwork.php
+++ b/src/EntryPoints/SpecialNetwork.php
@@ -25,7 +25,7 @@ class SpecialNetwork extends IncludableSpecialPage {
 		parent::__construct( 'Network' );
 	}
 
-	public function execute( ?string $subPage ): void {
+	public function execute( mixed $subPage ): void {
 		$this->setHeaders();
 
 		$config = new NetworkConfig();

--- a/src/EntryPoints/SpecialNetwork.php
+++ b/src/EntryPoints/SpecialNetwork.php
@@ -25,7 +25,7 @@ class SpecialNetwork extends IncludableSpecialPage {
 		parent::__construct( 'Network' );
 	}
 
-	public function execute( $subPage ): void {
+	public function execute( ?string $subPage ): void {
 		$this->setHeaders();
 
 		$config = new NetworkConfig();

--- a/src/EntryPoints/SpecialNetwork.php
+++ b/src/EntryPoints/SpecialNetwork.php
@@ -25,7 +25,8 @@ class SpecialNetwork extends IncludableSpecialPage {
 		parent::__construct( 'Network' );
 	}
 
-	public function execute( mixed $subPage ): void {
+	// phpcs:ignore MediaWiki.Commenting.FunctionComment.MissingDocumentationPublic
+	public function execute( $subPage ): void {
 		$this->setHeaders();
 
 		$config = new NetworkConfig();

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -28,17 +28,4 @@ class Extension {
 		return new SpecialNetworkPresenter();
 	}
 
-	public static function addMediaWiki131compat(): void {
-		// mediawiki.api.edit is present in 1.31 but not 1.32
-		// Once Maps requires MW 1.32+, this can be removed after replacing usage of mediawiki.api.edit
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
-			$GLOBALS['wgResourceModules']['mediawiki.api.edit'] = [
-				'dependencies' => [
-					'mediawiki.api'
-				],
-				'targets' => [ 'desktop', 'mobile' ]
-			];
-		}
-	}
-
 }

--- a/src/NetworkFunction/AbstractNetworkPresenter.php
+++ b/src/NetworkFunction/AbstractNetworkPresenter.php
@@ -8,12 +8,9 @@ use Html;
 
 abstract class AbstractNetworkPresenter implements NetworkPresenter {
 
-	private static $idCounter = 1;
+	private static int $idCounter = 1;
 
-	/**
-	 * @var string
-	 */
-	protected $html = '';
+	protected string $html = '';
 
 	public function setHtml( ResponseModel $viewModel ): void {
 		$this->html =

--- a/src/NetworkFunction/NetworkUseCase.php
+++ b/src/NetworkFunction/NetworkUseCase.php
@@ -6,10 +6,13 @@ namespace MediaWiki\Extension\Network\NetworkFunction;
 
 class NetworkUseCase {
 
-	private $presenter;
-	private $visJsOptions;
+	private NetworkPresenter $presenter;
+	private array $visJsOptions;
 
-	public function __construct( NetworkPresenter $presenter, array $visJsOptions ) {
+	public function __construct(
+		NetworkPresenter $presenter,
+		array $visJsOptions
+	) {
 		$this->presenter = $presenter;
 		$this->visJsOptions = $visJsOptions;
 	}
@@ -35,7 +38,6 @@ class NetworkUseCase {
 		$this->presenter->buildGraph( $response );
 	}
 
-
 	/**
 	 * @param string[] $arguments
 	 * @return string[]
@@ -44,9 +46,9 @@ class NetworkUseCase {
 		$pairs = [];
 
 		foreach ( $arguments as $argument ) {
-			[$key, $value] = $this->argumentStringToKeyValue( $argument );
+			[ $key, $value ] = $this->argumentStringToKeyValue( $argument );
 
-			if ( !is_null( $key ) ) {
+			if ( $key !== null ) {
 				$pairs[$key] = $value;
 			}
 		}
@@ -56,11 +58,11 @@ class NetworkUseCase {
 
 	private function argumentStringToKeyValue( string $argument ): array {
 		if ( false === strpos( $argument, '=' ) ) {
-			return [null, $argument];
+			return [ null, $argument ];
 		}
 
-		[$key, $value] = explode( '=', $argument );
-		return [trim($key), trim($value)];
+		[ $key, $value ] = explode( '=', $argument );
+		return [ trim( $key ), trim( $value ) ];
 	}
 
 	private function getVisJsOptions( array $arguments ): array {
@@ -79,7 +81,7 @@ class NetworkUseCase {
 		$pageNames = [];
 
 		foreach ( $request->functionArguments as $argument ) {
-			[$key, $value] = $this->argumentStringToKeyValue( $argument );
+			[ $key, $value ] = $this->argumentStringToKeyValue( $argument );
 
 			if ( $value !== '' && $this->isPageKey( $key ) ) {
 				foreach ( $this->pagesStringToArray( $value, '|' ) as $pageName ) {
@@ -96,7 +98,7 @@ class NetworkUseCase {
 	}
 
 	private function isPageKey( ?string $key ): bool {
-		return is_null( $key ) || in_array( $key, [ 'page', 'pages' ] );
+		return $key === null || in_array( $key, [ 'page', 'pages' ] );
 	}
 
 	/**
@@ -111,7 +113,7 @@ class NetworkUseCase {
 					'trim',
 					explode( $delimiter, $pages )
 				),
-				function( string $pageName ): bool {
+				static function ( string $pageName ): bool {
 					return $pageName !== '';
 				}
 			)
@@ -135,13 +137,13 @@ class NetworkUseCase {
 	 * @param int[] $excludedNamespaces
 	 * @return int[]
 	 */
-	private function getExcludedNamespaces(array $arguments, array $excludedNamespaces ): array {
+	private function getExcludedNamespaces( array $arguments, array $excludedNamespaces ): array {
 		if ( !isset( $arguments['excludedNamespaces'] ) ) {
 			return $excludedNamespaces;
 		}
 		$namespaces = explode( ',', $arguments['excludedNamespaces'] );
 		array_walk( $namespaces, 'intval' );
-		return  $namespaces;
+		return $namespaces;
 	}
 
 	/**
@@ -149,7 +151,7 @@ class NetworkUseCase {
 	 * @param bool $enableDisplayTitle
 	 * @return bool
 	 */
-	private function getEnableDisplayTitle(array $arguments, bool $enableDisplayTitle ): bool {
+	private function getEnableDisplayTitle( array $arguments, bool $enableDisplayTitle ): bool {
 		return isset( $arguments['enableDisplayTitle'] )
 			? filter_var( $arguments['enableDisplayTitle'], FILTER_VALIDATE_BOOLEAN )
 			: $enableDisplayTitle;
@@ -160,7 +162,7 @@ class NetworkUseCase {
 	 * @param int $labelMaxLength
 	 * @return int
 	 */
-	private function getLabelMaxLength(array $arguments, int $labelMaxLength ): int {
+	private function getLabelMaxLength( array $arguments, int $labelMaxLength ): int {
 		return isset( $arguments['labelMaxLength'] ) ? (int)$arguments['labelMaxLength'] : $labelMaxLength;
 	}
 }

--- a/src/NetworkFunction/NetworkUseCase.php
+++ b/src/NetworkFunction/NetworkUseCase.php
@@ -57,7 +57,7 @@ class NetworkUseCase {
 	}
 
 	private function argumentStringToKeyValue( string $argument ): array {
-		if ( false === strpos( $argument, '=' ) ) {
+		if ( strpos( $argument, '=' ) === false ) {
 			return [ null, $argument ];
 		}
 

--- a/src/NetworkFunction/ParserFunctionNetworkPresenter.php
+++ b/src/NetworkFunction/ParserFunctionNetworkPresenter.php
@@ -23,7 +23,7 @@ class ParserFunctionNetworkPresenter extends AbstractNetworkPresenter {
 	/**
 	 * @return array
 	 */
-	public function getReturnValue() : array {
+	public function getReturnValue(): array {
 		return $this->parserFunctionReturnValue;
 	}
 

--- a/src/NetworkFunction/RequestModel.php
+++ b/src/NetworkFunction/RequestModel.php
@@ -6,10 +6,16 @@ namespace MediaWiki\Extension\Network\NetworkFunction;
 
 class RequestModel {
 
-	public /* string[] */ $functionArguments;
-	public /* string */ $renderingPageName;
-	public /* int[] */ $excludedNamespaces;
-	public /* bool */ $enableDisplayTitle;
-	public /* int */ $labelMaxLength;
+	/** @var string[] */
+	public array $functionArguments;
+
+	public string $renderingPageName;
+
+	/** @var int[] */
+	public array $excludedNamespaces;
+
+	public bool $enableDisplayTitle;
+
+	public int $labelMaxLength;
 
 }

--- a/src/NetworkFunction/ResponseModel.php
+++ b/src/NetworkFunction/ResponseModel.php
@@ -6,12 +6,21 @@ namespace MediaWiki\Extension\Network\NetworkFunction;
 
 class ResponseModel {
 
-	public /* string[] */ $pageNames;
-	public /* string */ $cssClass;
-	public /* string[] */ $excludedPages;
-	public /* int[] */ $excludedNamespaces;
-	public /* bool */ $enableDisplayTitle;
-	public /* int */ $labelMaxLength;
-	public /* array */ $visJsOptions;
+	/** @var string[] */
+	public array $pageNames;
+
+	public string $cssClass;
+
+	/** @var string[] */
+	public array $excludedPages;
+
+	/** @var int[] */
+	public array $excludedNamespaces;
+
+	public bool $enableDisplayTitle;
+
+	public int $labelMaxLength;
+
+	public array $visJsOptions;
 
 }

--- a/tests/php/NetworkFunction/NetworkUseCaseTest.php
+++ b/tests/php/NetworkFunction/NetworkUseCaseTest.php
@@ -132,7 +132,7 @@ class NetworkUseCaseTest extends TestCase {
 	private function getPageNames( int $count ): array {
 		$pageNames = [];
 
-		for ( $i = 0 ; $i < $count ; $i++ ) {
+		for ( $i = 0; $i < $count; $i++ ) {
 			$pageNames[] = 'Page' . (string)$i;
 		}
 
@@ -142,7 +142,6 @@ class NetworkUseCaseTest extends TestCase {
 	public function testMoreThanMaxPagesResultsInError() {
 		$request = $this->newBasicRequestModel();
 		$request->functionArguments = $this->getPageNames( 101 );
-
 
 		$this->assertSame(
 			[ 'too many pages' ],
@@ -166,7 +165,6 @@ class NetworkUseCaseTest extends TestCase {
 			$this->runAndReturnPresenter( $request )->getResponseModel()->enableDisplayTitle
 		);
 	}
-
 
 	public function testOverrideEnableDisplayTitleFalse() {
 		$request = $this->newBasicRequestModel();

--- a/tests/php/NetworkFunction/SpyNetworkPresenter.php
+++ b/tests/php/NetworkFunction/SpyNetworkPresenter.php
@@ -28,7 +28,7 @@ class SpyNetworkPresenter implements NetworkPresenter {
 		return $this->errors;
 	}
 
-	public function getReturnValue() {
+	public function getReturnValue(): array {
 		return [];
 	}
 

--- a/tests/php/NetworkFunction/SpyNetworkPresenter.php
+++ b/tests/php/NetworkFunction/SpyNetworkPresenter.php
@@ -9,8 +9,8 @@ use MediaWiki\Extension\Network\NetworkFunction\ResponseModel;
 
 class SpyNetworkPresenter implements NetworkPresenter {
 
-	private $viewModel;
-	private $errors = [];
+	private ResponseModel $viewModel;
+	private array $errors = [];
 
 	public function buildGraph( ResponseModel $viewModel ): void {
 		$this->viewModel = $viewModel;

--- a/tests/php/NetworkFunctionIntegrationTest.php
+++ b/tests/php/NetworkFunctionIntegrationTest.php
@@ -17,14 +17,14 @@ class NetworkFunctionIntegrationTest extends TestCase {
 	}
 
 	public function testWhenThereAreNoParameters_contextPageIsUsed() {
-		$this->assertContains(
+		$this->assertStringContainsString(
 			'data-pages="[&quot;ContextPageTitle&quot;]"',
 			$this->parse( '{{#network:}}' )
 		);
 	}
 
 	public function testOptionsParameters() {
-		$this->assertContains(
+		$this->assertStringContainsString(
 			'&quot;shape&quot;:&quot;tomato&quot;',
 			$this->parse( '{{#network:options={"nodes": {"shape": "tomato"} } }}' )
 		);

--- a/tests/php/NetworkFunctionIntegrationTest.php
+++ b/tests/php/NetworkFunctionIntegrationTest.php
@@ -7,6 +7,9 @@ namespace MediaWiki\Extension\Network\Tests;
 use MediaWiki\MediaWikiServices;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \MediaWiki\Extension\Network\EntryPoints\NetworkFunction
+ */
 class NetworkFunctionIntegrationTest extends TestCase {
 
 	private const PAGE_TITLE = 'ContextPageTitle';


### PR DESCRIPTION
- Raise minimum MediaWiki requirements to 1.39
- Add `phpcs` and `mediawiki/mediawiki-codesniffer`
- Update CI to run on MW 1.39+ versions and PHP 7.4+
- Fix various errors raised by CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Upgraded the extension to version 3.0.0, now compatible with newer MediaWiki releases (version 1.39+).
  - Introduced an automated setup tool to streamline MediaWiki installation and configuration.

- **Chores**
  - Enhanced internal automation and quality checks to improve overall stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->