### PR TITLE
Add imports for namespaced Html and Title classes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,19 +17,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - mw: 'REL1_39'
-            php: 7.4
-            experimental: false
-          - mw: 'REL1_40'
-            php: 8.0
-            experimental: false
-          - mw: 'REL1_41'
-            php: 8.1
-            experimental: false
-          - mw: 'REL1_42'
-            php: 8.2
-            experimental: false
           - mw: 'REL1_43'
+            php: 8.3
+            experimental: false
+          - mw: 'REL1_44'
             php: 8.3
             experimental: false
           - mw: 'master'
@@ -70,7 +61,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: EarlyCopy
-  
+
       - name: Install MediaWiki
         if: steps.cache-mediawiki.outputs.cache-hit != 'true'
         working-directory: ~
@@ -128,12 +119,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: EarlyCopy
-  
+
       - name: Install MediaWiki
         if: steps.cache-mediawiki.outputs.cache-hit != 'true'
         working-directory: ~
         run: bash EarlyCopy/.github/workflows/installMediaWiki.sh ${{ matrix.mw }} Network
-  
+
       - uses: actions/checkout@v4
         with:
           path: mediawiki/extensions/Network

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ It was created by [Professional Wiki] and funded by
 
 ## Platform requirements
 
-- PHP 7.4 or later (tested up to PHP 8.4)
-- MediaWiki 1.39.x or later (tested up to 1.43.x)
+- PHP 8.1 or later (tested up to PHP 8.4)
+- MediaWiki 1.43.x or later (tested up to 1.44.x)
 
 See the [release notes](#release-notes) for more information on the different versions of Network.
 
@@ -364,6 +364,12 @@ The JavaScript tests can only be run by going to the [`Special:JavaScriptTest` p
 [Professional Wiki] provides commercial [MediaWiki development], [managed wiki hosting] and [MediaWiki support].
 
 ## Release notes
+
+### Version 4.0.0
+
+Released on July 22nd, 2025.
+
+- Raised minimum MediaWiki version from 1.39 to 1.43
 
 ### Version 3.0.0
 

--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ The JavaScript tests can only be run by going to the [`Special:JavaScriptTest` p
 
 Released on July 22nd, 2025.
 
+- Raised minimum PHP version from 7.4 to 8.1
 - Raised minimum MediaWiki version from 1.39 to 1.43
 
 ### Version 3.0.0

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
 		"source": "https://github.com/ProfessionalWiki/Network"
 	},
 	"require": {
-		"php": ">=7.4",
+		"php": ">=8.1",
 		"composer/installers": "^2|^1.0.1"
 	},
 	"require-dev": {

--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
 	"name": "Network",
 
-	"version": "3.0.0",
+	"version": "4.0.0",
 
 	"author": [
 		"[https://www.entropywins.wtf/mediawiki Jeroen De Dauw]",
@@ -17,7 +17,7 @@
 	"type": "parserhook",
 
 	"requires": {
-		"MediaWiki": ">= 1.39.0"
+		"MediaWiki": ">= 1.43.0"
 	},
 
 	"config": {

--- a/src/EntryPoints/NetworkFunction.php
+++ b/src/EntryPoints/NetworkFunction.php
@@ -9,8 +9,8 @@ use MediaWiki\Extension\Network\NetworkFunction\NetworkConfig;
 use MediaWiki\Extension\Network\NetworkFunction\NetworkPresenter;
 use MediaWiki\Extension\Network\NetworkFunction\NetworkUseCase;
 use MediaWiki\Extension\Network\NetworkFunction\RequestModel;
+use MediaWiki\Title\Title;
 use Parser;
-use Title;
 
 class NetworkFunction {
 

--- a/src/EntryPoints/SpecialNetwork.php
+++ b/src/EntryPoints/SpecialNetwork.php
@@ -4,16 +4,16 @@ declare( strict_types = 1 );
 
 namespace MediaWiki\Extension\Network\EntryPoints;
 
-use Html;
 use IncludableSpecialPage;
 use MediaWiki\Extension\Network\Extension;
 use MediaWiki\Extension\Network\NetworkFunction\NetworkConfig;
 use MediaWiki\Extension\Network\NetworkFunction\NetworkPresenter;
 use MediaWiki\Extension\Network\NetworkFunction\NetworkUseCase;
 use MediaWiki\Extension\Network\NetworkFunction\RequestModel;
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
 use Message;
-use Title;
 use WebRequest;
 
 /**

--- a/src/NetworkFunction/AbstractNetworkPresenter.php
+++ b/src/NetworkFunction/AbstractNetworkPresenter.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 
 namespace MediaWiki\Extension\Network\NetworkFunction;
 
-use Html;
+use MediaWiki\Html\Html;
 
 abstract class AbstractNetworkPresenter implements NetworkPresenter {
 

--- a/tests/php/NetworkFunctionIntegrationTest.php
+++ b/tests/php/NetworkFunctionIntegrationTest.php
@@ -5,7 +5,9 @@ declare( strict_types = 1 );
 namespace MediaWiki\Extension\Network\Tests;
 
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Parser\ParserOptions;
 use MediaWiki\Title\Title;
+use MediaWiki\User\User;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,8 +18,11 @@ class NetworkFunctionIntegrationTest extends TestCase {
 	private const PAGE_TITLE = 'ContextPageTitle';
 
 	private function parse( string $textToParse ): string {
+		$parserOptions = new ParserOptions( User::newSystemUser( 'TestUser' ) );
 		return MediaWikiServices::getInstance()->getParser()
-			->parse( $textToParse, Title::newFromText( self::PAGE_TITLE ), new \ParserOptions( \User::newSystemUser( 'TestUser' ) ) )->getText();
+			->parse( $textToParse, Title::newFromText( self::PAGE_TITLE ), $parserOptions )
+			->runOutputPipeline( $parserOptions )
+			->getContentHolderText();
 	}
 
 	public function testWhenThereAreNoParameters_contextPageIsUsed() {

--- a/tests/php/NetworkFunctionIntegrationTest.php
+++ b/tests/php/NetworkFunctionIntegrationTest.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace MediaWiki\Extension\Network\Tests;
 
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,7 +17,7 @@ class NetworkFunctionIntegrationTest extends TestCase {
 
 	private function parse( string $textToParse ): string {
 		return MediaWikiServices::getInstance()->getParser()
-			->parse( $textToParse, \Title::newFromText( self::PAGE_TITLE ), new \ParserOptions( \User::newSystemUser( 'TestUser' ) ) )->getText();
+			->parse( $textToParse, Title::newFromText( self::PAGE_TITLE ), new \ParserOptions( \User::newSystemUser( 'TestUser' ) ) )->getText();
 	}
 
 	public function testWhenThereAreNoParameters_contextPageIsUsed() {


### PR DESCRIPTION
Fixes compatibility with MW 1.44.
Raise MW requirement to 1.40 accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated minimum required MediaWiki version in documentation to 1.43.x and PHP version to 8.1.
  * Added release notes entry for version 4.0.0.
* **Chores**
  * Increased minimum required MediaWiki version in extension configuration to 1.43.0.
  * Cleaned up workflow files and removed support for older MediaWiki/PHP versions; added support for MediaWiki 1.44 with PHP 8.3.
  * Updated PHP version requirement in composer configuration to 8.1.
* **Style**
  * Updated import statements to use fully qualified MediaWiki class namespaces.
* **Tests**
  * Improved parsing test flow to include output pipeline processing and consistent parser options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->