### PR TITLE
Fix page dedup cache preventing retry after failed API calls

### DIFF
--- a/resources/js/ApiPageConnectionRepo.js
+++ b/resources/js/ApiPageConnectionRepo.js
@@ -25,10 +25,9 @@ module.ApiPageConnectionRepo = ( function ( mw, ApiConnectionsBuilder ) {
 				if (pagesToAdd.length === 0) {
 					resolve({pages: [], links: []});
 				} else {
-					this._addedPages = this._addedPages.concat(pagesToAdd);
-
 					this._queryLinks(pagesToAdd).done(
 						function(apiResponse) {
+							this._addedPages = this._addedPages.concat(pagesToAdd);
 							this._apiResponseToPagesAndLinks(apiResponse).then(connections => resolve(connections))
 						}.bind(this)
 					);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected page connection handling to ensure pages are marked as added only after API confirmation is received, preventing potential data inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->