### PR TITLE
Modernise PHP code: MW 1.43 namespaces, native types, readonly

### DIFF
--- a/src/EntryPoints/NetworkFunction.php
+++ b/src/EntryPoints/NetworkFunction.php
@@ -14,13 +14,9 @@ use MediaWiki\Title\Title;
 
 class NetworkFunction {
 
-	/**
-	 * @var NetworkConfig
-	 */
-	private $config;
-
-	public function __construct( NetworkConfig $config ) {
-		$this->config = $config;
+	public function __construct(
+		private readonly NetworkConfig $config
+	) {
 	}
 
 	public static function onParserFirstCallInit( Parser $parser ): void {

--- a/src/EntryPoints/NetworkFunction.php
+++ b/src/EntryPoints/NetworkFunction.php
@@ -9,8 +9,8 @@ use MediaWiki\Extension\Network\NetworkFunction\NetworkConfig;
 use MediaWiki\Extension\Network\NetworkFunction\NetworkPresenter;
 use MediaWiki\Extension\Network\NetworkFunction\NetworkUseCase;
 use MediaWiki\Extension\Network\NetworkFunction\RequestModel;
+use MediaWiki\Parser\Parser;
 use MediaWiki\Title\Title;
-use Parser;
 
 class NetworkFunction {
 

--- a/src/EntryPoints/NetworkFunction.php
+++ b/src/EntryPoints/NetworkFunction.php
@@ -32,12 +32,7 @@ class NetworkFunction {
 		);
 	}
 
-	/**
-	 * @param Parser $parser
-	 * @param string ...$arguments
-	 * @return array|string
-	 */
-	public function handleParserFunctionCall( Parser $parser, string ...$arguments ) {
+	public function handleParserFunctionCall( Parser $parser, string ...$arguments ): array|string {
 		$parser->getOutput()->addModules( [ 'ext.network' ] );
 		$parser->getOutput()->setJsConfigVar( 'networkExcludeTalkPages', $this->config->getExcludeTalkPages() );
 

--- a/src/EntryPoints/SpecialNetwork.php
+++ b/src/EntryPoints/SpecialNetwork.php
@@ -25,7 +25,9 @@ class SpecialNetwork extends IncludableSpecialPage {
 		parent::__construct( 'Network' );
 	}
 
-	// phpcs:ignore MediaWiki.Commenting.FunctionComment.MissingDocumentationPublic
+	/**
+	 * @inheritDoc
+	 */
 	public function execute( $subPage ): void {
 		$this->setHeaders();
 

--- a/src/EntryPoints/SpecialNetwork.php
+++ b/src/EntryPoints/SpecialNetwork.php
@@ -4,7 +4,6 @@ declare( strict_types = 1 );
 
 namespace MediaWiki\Extension\Network\EntryPoints;
 
-use IncludableSpecialPage;
 use MediaWiki\Extension\Network\Extension;
 use MediaWiki\Extension\Network\NetworkFunction\NetworkConfig;
 use MediaWiki\Extension\Network\NetworkFunction\NetworkPresenter;
@@ -12,9 +11,10 @@ use MediaWiki\Extension\Network\NetworkFunction\NetworkUseCase;
 use MediaWiki\Extension\Network\NetworkFunction\RequestModel;
 use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Message\Message;
+use MediaWiki\Request\WebRequest;
+use MediaWiki\SpecialPage\IncludableSpecialPage;
 use MediaWiki\Title\Title;
-use Message;
-use WebRequest;
 
 /**
  * @psalm-suppress PropertyNotSetInConstructor

--- a/src/NetworkFunction/NetworkConfig.php
+++ b/src/NetworkFunction/NetworkConfig.php
@@ -7,30 +7,13 @@ namespace MediaWiki\Extension\Network\NetworkFunction;
 use MediaWiki\MediaWikiServices;
 
 class NetworkConfig {
-	/**
-	 * @var array
-	 */
-	private $options;
 
-	/**
-	 * @var bool
-	 */
-	private $excludeTalkPages;
-
-	/**
-	 * @var string[]
-	 */
-	private $excludedNamespaces;
-
-	/**
-	 * @var bool
-	 */
-	private $enableDisplayTitle;
-
-	/**
-	 * @var int
-	 */
-	private $labelMaxLength;
+	private readonly array $options;
+	private readonly bool $excludeTalkPages;
+	/** @var string[] */
+	private readonly array $excludedNamespaces;
+	private readonly bool $enableDisplayTitle;
+	private readonly int $labelMaxLength;
 
 	public function __construct() {
 		$config = MediaWikiServices::getInstance()->getMainConfig();

--- a/src/NetworkFunction/NetworkUseCase.php
+++ b/src/NetworkFunction/NetworkUseCase.php
@@ -6,15 +6,10 @@ namespace MediaWiki\Extension\Network\NetworkFunction;
 
 class NetworkUseCase {
 
-	private NetworkPresenter $presenter;
-	private array $visJsOptions;
-
 	public function __construct(
-		NetworkPresenter $presenter,
-		array $visJsOptions
+		private readonly NetworkPresenter $presenter,
+		private readonly array $visJsOptions
 	) {
-		$this->presenter = $presenter;
-		$this->visJsOptions = $visJsOptions;
 	}
 
 	public function run( RequestModel $request ): void {

--- a/src/NetworkFunction/ParserFunctionNetworkPresenter.php
+++ b/src/NetworkFunction/ParserFunctionNetworkPresenter.php
@@ -6,10 +6,7 @@ namespace MediaWiki\Extension\Network\NetworkFunction;
 
 class ParserFunctionNetworkPresenter extends AbstractNetworkPresenter {
 
-	/**
-	 * @var array
-	 */
-	private $parserFunctionReturnValue = [];
+	private array $parserFunctionReturnValue = [];
 
 	public function buildGraph( ResponseModel $viewModel ): void {
 		$this->setHtml( $viewModel );

--- a/src/NetworkFunction/SpecialNetworkPresenter.php
+++ b/src/NetworkFunction/SpecialNetworkPresenter.php
@@ -10,10 +10,7 @@ class SpecialNetworkPresenter extends AbstractNetworkPresenter {
 		$this->setHtml( $viewModel );
 	}
 
-	/**
-	 * @return string
-	 */
-	public function getReturnValue() {
+	public function getReturnValue(): string {
 		return $this->html;
 	}
 

--- a/tests/php/NetworkFunction/NetworkUseCaseTest.php
+++ b/tests/php/NetworkFunction/NetworkUseCaseTest.php
@@ -15,7 +15,7 @@ class NetworkUseCaseTest extends TestCase {
 
 	private const RENDERING_PAGE_NAME = 'MyPage';
 
-	public function testDefaultPageName() {
+	public function testDefaultPageName(): void {
 		$this->assertSame(
 			[ self::RENDERING_PAGE_NAME ],
 			$this->runAndReturnPresenter( $this->newBasicRequestModel() )->getResponseModel()->pageNames
@@ -53,7 +53,7 @@ class NetworkUseCaseTest extends TestCase {
 		return $request;
 	}
 
-	public function testSpecifiedPageName() {
+	public function testSpecifiedPageName(): void {
 		$request = $this->newBasicRequestModel();
 		$request->functionArguments = [ 'page = Kittens' ];
 
@@ -63,7 +63,7 @@ class NetworkUseCaseTest extends TestCase {
 		);
 	}
 
-	public function testDefaultCssClass() {
+	public function testDefaultCssClass(): void {
 		$request = $this->newBasicRequestModel();
 
 		$this->assertSame(
@@ -72,7 +72,7 @@ class NetworkUseCaseTest extends TestCase {
 		);
 	}
 
-	public function testSpecifiedCssClass() {
+	public function testSpecifiedCssClass(): void {
 		$request = $this->newBasicRequestModel();
 		$request->functionArguments = [ 'class = col-lg-3 mt-2 ' ];
 
@@ -82,7 +82,7 @@ class NetworkUseCaseTest extends TestCase {
 		);
 	}
 
-	public function testMultiplePageNames() {
+	public function testMultiplePageNames(): void {
 		$request = $this->newBasicRequestModel();
 		$request->functionArguments = [ 'Kittens', 'Cats', 'page = Tigers', 'page=Bobcats ' ];
 
@@ -92,7 +92,7 @@ class NetworkUseCaseTest extends TestCase {
 		);
 	}
 
-	public function testPageParametersWithPipe() {
+	public function testPageParametersWithPipe(): void {
 		$request = $this->newBasicRequestModel();
 		$request->functionArguments = [ 'Kittens|Cats', 'pages = Tigers|Bobcats' ];
 
@@ -102,14 +102,14 @@ class NetworkUseCaseTest extends TestCase {
 		);
 	}
 
-	public function testNothingExcludedByDefault() {
+	public function testNothingExcludedByDefault(): void {
 		$this->assertSame(
 			[],
 			$this->runAndReturnPresenter( $this->newBasicRequestModel() )->getResponseModel()->excludedPages
 		);
 	}
 
-	public function testExclude() {
+	public function testExclude(): void {
 		$request = $this->newBasicRequestModel();
 		$request->functionArguments = [ 'Kittens', 'exclude = Foo ; Bar ; Baz:bah' ];
 
@@ -119,7 +119,7 @@ class NetworkUseCaseTest extends TestCase {
 		);
 	}
 
-	public function testCanUseMaxPages() {
+	public function testCanUseMaxPages(): void {
 		$request = $this->newBasicRequestModel();
 		$request->functionArguments = $this->getPageNames( 100 );
 
@@ -139,7 +139,7 @@ class NetworkUseCaseTest extends TestCase {
 		return $pageNames;
 	}
 
-	public function testMoreThanMaxPagesResultsInError() {
+	public function testMoreThanMaxPagesResultsInError(): void {
 		$request = $this->newBasicRequestModel();
 		$request->functionArguments = $this->getPageNames( 101 );
 
@@ -149,7 +149,7 @@ class NetworkUseCaseTest extends TestCase {
 		);
 	}
 
-	public function testDefaultEnableDisplayTitle() {
+	public function testDefaultEnableDisplayTitle(): void {
 		$request = $this->newBasicRequestModel();
 
 		$this->assertTrue(
@@ -157,7 +157,7 @@ class NetworkUseCaseTest extends TestCase {
 		);
 	}
 
-	public function testOverrideEnableDisplayTitleTrue() {
+	public function testOverrideEnableDisplayTitleTrue(): void {
 		$request = $this->newBasicRequestModel();
 		$request->functionArguments = [ 'enableDisplayTitle = true' ];
 
@@ -166,7 +166,7 @@ class NetworkUseCaseTest extends TestCase {
 		);
 	}
 
-	public function testOverrideEnableDisplayTitleFalse() {
+	public function testOverrideEnableDisplayTitleFalse(): void {
 		$request = $this->newBasicRequestModel();
 		$request->functionArguments = [ 'enableDisplayTitle = false' ];
 
@@ -175,7 +175,7 @@ class NetworkUseCaseTest extends TestCase {
 		);
 	}
 
-	public function testNoOptionsInLocalSettingsAndNoOptionsParameter() {
+	public function testNoOptionsInLocalSettingsAndNoOptionsParameter(): void {
 		$presenter = new SpyNetworkPresenter();
 		( new NetworkUseCase( $presenter, [] ) )->run( $this->newBasicRequestModel() );
 
@@ -185,7 +185,7 @@ class NetworkUseCaseTest extends TestCase {
 		);
 	}
 
-	public function testOptionsInLocalSettings() {
+	public function testOptionsInLocalSettings(): void {
 		$setting = [
 			'height' => '42%',
 			'layout' => [
@@ -202,7 +202,7 @@ class NetworkUseCaseTest extends TestCase {
 		);
 	}
 
-	public function testOptionsParameter() {
+	public function testOptionsParameter(): void {
 		$request = $this->newBasicRequestModel();
 		$request->functionArguments = [ 'options={"nodes": {"shape": "box"}}' ];
 
@@ -219,7 +219,7 @@ class NetworkUseCaseTest extends TestCase {
 		);
 	}
 
-	public function testOptionsParameterWithLocalSettingsConfig() {
+	public function testOptionsParameterWithLocalSettingsConfig(): void {
 		$setting = [
 			'height' => '42%',
 			'nodes' => [

--- a/tests/php/NetworkFunction/SpyNetworkPresenter.php
+++ b/tests/php/NetworkFunction/SpyNetworkPresenter.php
@@ -9,7 +9,7 @@ use MediaWiki\Extension\Network\NetworkFunction\ResponseModel;
 
 class SpyNetworkPresenter implements NetworkPresenter {
 
-	private ResponseModel $viewModel;
+	private ?ResponseModel $viewModel = null;
 	private array $errors = [];
 
 	public function buildGraph( ResponseModel $viewModel ): void {

--- a/tests/php/NetworkFunctionIntegrationTest.php
+++ b/tests/php/NetworkFunctionIntegrationTest.php
@@ -25,14 +25,14 @@ class NetworkFunctionIntegrationTest extends TestCase {
 			->getContentHolderText();
 	}
 
-	public function testWhenThereAreNoParameters_contextPageIsUsed() {
+	public function testWhenThereAreNoParameters_contextPageIsUsed(): void {
 		$this->assertStringContainsString(
 			'data-pages="[&quot;ContextPageTitle&quot;]"',
 			$this->parse( '{{#network:}}' )
 		);
 	}
 
-	public function testOptionsParameters() {
+	public function testOptionsParameters(): void {
 		$this->assertStringContainsString(
 			'&quot;shape&quot;:&quot;tomato&quot;',
 			$this->parse( '{{#network:options={"nodes": {"shape": "tomato"} } }}' )


### PR DESCRIPTION
## Summary

Conservative pass on the PHP source to use:

- **MW 1.43 namespaced classes** for `Parser`, `IncludableSpecialPage`, `Message`, `WebRequest` (was: bare top-level imports). Side benefit: resolves three pre-existing psalm `UndefinedClass` errors.
- **Native property types** in `NetworkConfig` and `ParserFunctionNetworkPresenter` (was: `@var` docblocks). `NetworkConfig` properties are now `readonly`.
- **Native return types** on `NetworkFunction::handleParserFunctionCall(): array|string` and `SpecialNetworkPresenter::getReturnValue(): string` (was: docblock-only).
- **Constructor property promotion + `readonly`** on `NetworkFunction` and `NetworkUseCase`.
- **Test type fix** — `SpyNetworkPresenter::$viewModel` is now `?ResponseModel = null` to match its already-nullable getter (real bug, not just style).
- **Test method return types** — `: void` added to all test methods in `NetworkUseCaseTest` and `NetworkFunctionIntegrationTest`.

PHP floor and MediaWiki floor are unchanged.

### Deviation from spec

The spec proposed `SpecialNetwork::execute( ?string $subPage )` to drop the `phpcs:ignore`. That can't actually happen — `SpecialPage::execute( $subPage )` in MW core has no native type, so adding `?string` is an LSP-narrowing that both phpstan and psalm reject. Replaced the `phpcs:ignore` with `@inheritDoc` instead, which satisfies the missing-docblock check without restating the parent.

### Out of scope (intentional)

- Replacing `MediaWikiServices::getInstance()` in `NetworkConfig` with proper DI.
- Replacing the public-set `RequestModel`/`ResponseModel` DTOs with constructor-based readonly objects.
- Removing the `Extension::getFactory()` static indirection.
- Resolving the `psalm-suppress` annotations in `SpecialNetwork.php`.

## Test plan

Local verification (full quality suite green on combined HEAD against the dev wiki):

- [x] `composer phpunit` → 19/19 tests pass
- [x] `vendor/bin/phpcs -p -s` → 14/14 files clean
- [x] `vendor/bin/phpstan analyse` → No errors
- [x] `vendor/bin/psalm` → No errors found

CI (matrix from the recent CI-update PR):

- [ ] All five PHPUnit rows pass (REL1_43+8.1, REL1_43+8.2, REL1_44+8.3, REL1_45+8.4); master+8.5 reaches the test phase
- [ ] Static Analysis (REL1_43+8.3) passes
- [ ] Code style (REL1_43+8.3) passes