### PR TITLE
Inline Codex icons in PageNetworkOptions and fix Title Icon URL

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -48,10 +48,10 @@
 				},
 				"groups": {
 					"bluelink": {
-						"image": "resources/lib/ooui/themes/wikimediaui/images/icons/article-rtl-progressive.svg"
+						"image": "cdxIconArticle"
 					},
 					"redlink": {
-						"image": "resources/lib/ooui/themes/wikimediaui/images/icons/articleNotFound-ltr.svg",
+						"image": "cdxIconArticleNotFound",
 						"color": {
 							"border": "#ba0000",
 							"highlight": {
@@ -63,7 +63,7 @@
 						}
 					},
 					"externallink": {
-						"image": "resources/lib/ooui/themes/wikimediaui/images/icons/linkExternal-ltr-progressive.svg",
+						"image": "cdxIconLinkExternal",
 						"color": {
 							"border": "grey",
 							"highlight": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,3 +8,11 @@ parameters:
 		- ../../vendor
 	bootstrapFiles:
 		- ../../includes/AutoLoader.php
+	ignoreErrors:
+		# MW_INSTALL_PATH is defined by MediaWiki's entry-point bootstrap
+		# (index.php, api.php, maintenance scripts), not by AutoLoader.php.
+		# MW core itself uses this constant directly (see CodexModule.php);
+		# there is no equivalent on the Config service in MW 1.44+.
+		-
+			message: '#Constant MW_INSTALL_PATH not found\.#'
+			path: src/Extension.php

--- a/psalm.xml
+++ b/psalm.xml
@@ -32,5 +32,13 @@
 				<file name="src/EntryPoints/SpecialNetwork.php" />
 			</errorLevel>
 		</UndefinedDocblockClass>
+		<UndefinedConstant>
+			<errorLevel type="suppress">
+				<!-- MW_INSTALL_PATH is set by MediaWiki's runtime bootstrap.
+				     MW core uses this constant directly (CodexModule.php);
+				     there is no equivalent on the Config service in MW 1.44+. -->
+				<file name="src/Extension.php" />
+			</errorLevel>
+		</UndefinedConstant>
 	</issueHandlers>
 </psalm>

--- a/resources/js/ApiPageConnectionRepo.js
+++ b/resources/js/ApiPageConnectionRepo.js
@@ -176,7 +176,8 @@ module.ApiPageConnectionRepo = ( function ( mw, ApiConnectionsBuilder ) {
 							for (let index in icons) {
 								let icon = icons[index]
 								if (icon.type === 'ooui') {
-									images[page.title] = 'resources/lib/ooui/themes/wikimediaui/images/icons/' + icon.icon;
+									images[page.title] = (mw.config.get('wgScriptPath') || '')
+										+ '/resources/lib/ooui/themes/wikimediaui/images/icons/' + icon.icon;
 									break
 								} else if (icon.type === 'file') {
 									fileIcons[page.title] = icon.icon;

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -4,20 +4,34 @@ declare( strict_types = 1 );
 
 namespace MediaWiki\Extension\Network;
 
+use MediaWiki\Extension\Network\NetworkFunction\IconResolver;
 use MediaWiki\Extension\Network\NetworkFunction\NetworkConfig;
 use MediaWiki\Extension\Network\NetworkFunction\NetworkPresenter;
 use MediaWiki\Extension\Network\NetworkFunction\NetworkUseCase;
 use MediaWiki\Extension\Network\NetworkFunction\ParserFunctionNetworkPresenter;
 use MediaWiki\Extension\Network\NetworkFunction\SpecialNetworkPresenter;
+use MediaWiki\MainConfigNames;
+use MediaWiki\MediaWikiServices;
 
 class Extension {
 
+	public function __construct(
+		private readonly IconResolver $iconResolver
+	) {
+	}
+
 	public static function getFactory(): self {
-		return new self();
+		$mainConfig = MediaWikiServices::getInstance()->getMainConfig();
+		return new self(
+			new IconResolver(
+				MW_INSTALL_PATH . '/resources/lib/codex-icons/codex-icons.json',
+				$mainConfig->get( MainConfigNames::ScriptPath )
+			)
+		);
 	}
 
 	public function newNetworkFunction( NetworkPresenter $presenter, NetworkConfig $config ): NetworkUseCase {
-		return new NetworkUseCase( $presenter, $config->getOptions() );
+		return new NetworkUseCase( $presenter, $config->getOptions(), $this->iconResolver );
 	}
 
 	public function newParserFunctionNetworkPresenter(): ParserFunctionNetworkPresenter {

--- a/src/NetworkFunction/IconResolver.php
+++ b/src/NetworkFunction/IconResolver.php
@@ -1,0 +1,108 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace MediaWiki\Extension\Network\NetworkFunction;
+
+use MediaWiki\Logger\LoggerFactory;
+
+class IconResolver {
+
+	private ?array $iconData = null;
+
+	public function __construct(
+		private readonly string $codexIconsJsonPath,
+		private readonly string $scriptPath
+	) {
+	}
+
+	public function resolve( array $visJsOptions ): array {
+		if ( !isset( $visJsOptions['groups'] ) || !is_array( $visJsOptions['groups'] ) ) {
+			return $visJsOptions;
+		}
+		foreach ( $visJsOptions['groups'] as $name => $group ) {
+			if ( is_array( $group ) && isset( $group['image'] ) && is_string( $group['image'] ) ) {
+				$visJsOptions['groups'][$name]['image'] = $this->resolveImage( $group['image'] );
+			}
+		}
+		return $visJsOptions;
+	}
+
+	private function resolveImage( string $value ): string {
+		if ( preg_match( '/^cdxIcon[A-Z]/', $value ) === 1 ) {
+			$resolved = $this->codexIconToDataUri( $value );
+			if ( $resolved === null ) {
+				LoggerFactory::getInstance( 'Network' )->warning(
+					'Unknown or unsupported Codex icon "{name}" in PageNetworkOptions; '
+						. 'falling back to literal value (will likely fail to load).',
+					[ 'name' => $value ]
+				);
+				return $value;
+			}
+			return $resolved;
+		}
+		if ( $this->isAbsoluteUrl( $value ) ) {
+			return $value;
+		}
+		return $this->scriptPath . '/' . $value;
+	}
+
+	private function isAbsoluteUrl( string $value ): bool {
+		return str_starts_with( $value, 'http://' )
+			|| str_starts_with( $value, 'https://' )
+			|| str_starts_with( $value, '//' )
+			|| str_starts_with( $value, '/' )
+			|| str_starts_with( $value, 'data:' );
+	}
+
+	private function codexIconToDataUri( string $iconName ): ?string {
+		$path = $this->extractPath( $this->loadIcons()[$iconName] ?? null );
+		if ( $path === null ) {
+			return null;
+		}
+		// Codex icons are authored on a 20x20 grid.
+		// See https://doc.wikimedia.org/codex/main/style-guide/icons.html
+		$svg = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">'
+			. $path
+			. '</svg>';
+		return 'data:image/svg+xml;base64,' . base64_encode( $svg );
+	}
+
+	/**
+	 * codex-icons.json stores entries in three shapes:
+	 *  - a plain string of SVG path markup (e.g. cdxIconAdd)
+	 *  - an associative array with an 'ltr' key (e.g. cdxIconArticle)
+	 *  - an associative array with a 'default' key plus a 'langCodeMap' (e.g. cdxIconBold)
+	 *
+	 * Returns the SVG path markup for any of these, preferring 'ltr' when available
+	 * and falling back to 'default'. Returns null for shapes we don't understand.
+	 */
+	private function extractPath( mixed $icon ): ?string {
+		if ( is_string( $icon ) ) {
+			return $icon;
+		}
+		if ( !is_array( $icon ) ) {
+			return null;
+		}
+		if ( isset( $icon['ltr'] ) && is_string( $icon['ltr'] ) ) {
+			return $icon['ltr'];
+		}
+		if ( isset( $icon['default'] ) && is_string( $icon['default'] ) ) {
+			return $icon['default'];
+		}
+		return null;
+	}
+
+	private function loadIcons(): array {
+		if ( $this->iconData === null ) {
+			if ( is_readable( $this->codexIconsJsonPath ) ) {
+				$json = file_get_contents( $this->codexIconsJsonPath );
+				$this->iconData = ( $json !== false ? json_decode( $json, true ) : null ) ?? [];
+			} else {
+				$this->iconData = [];
+			}
+		}
+		return $this->iconData;
+	}
+
+}

--- a/src/NetworkFunction/NetworkUseCase.php
+++ b/src/NetworkFunction/NetworkUseCase.php
@@ -8,7 +8,8 @@ class NetworkUseCase {
 
 	public function __construct(
 		private readonly NetworkPresenter $presenter,
-		private readonly array $visJsOptions
+		private readonly array $visJsOptions,
+		private readonly IconResolver $iconResolver
 	) {
 	}
 
@@ -65,7 +66,7 @@ class NetworkUseCase {
 			$this->visJsOptions,
 			json_decode( $arguments['options'] ?? '{}', true ) ?? []
 		);
-		return $visJsOptions;
+		return $this->iconResolver->resolve( $visJsOptions );
 	}
 
 	/**

--- a/tests/php/NetworkFunction/IconResolverTest.php
+++ b/tests/php/NetworkFunction/IconResolverTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace MediaWiki\Extension\Network\Tests\NetworkFunction;
+
+use MediaWiki\Extension\Network\NetworkFunction\IconResolver;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Network\NetworkFunction\IconResolver
+ */
+class IconResolverTest extends TestCase {
+
+	private const FIXTURE_ICONS = [
+		'cdxIconArticle' => [
+			'ltr' => '<path d="M5 1h10z"/>',
+			'shouldFlip' => true,
+		],
+		'cdxIconLinkExternal' => [
+			'ltr' => '<path d="M1 2h2z"/>',
+		],
+		// Plain-string shape (155 of MW's bundled icons use this form, e.g. cdxIconAdd).
+		'cdxIconAdd' => '<path d="M11 9V4z"/>',
+		// {default, langCodeMap} shape (e.g. cdxIconBold).
+		'cdxIconBold' => [
+			'default' => '<path d="M3 19h7z"/>',
+			'langCodeMap' => [ 'en' => '<path d="M-default-replaced/>' ],
+		],
+	];
+
+	private string $fixturePath;
+
+	protected function setUp(): void {
+		$this->fixturePath = tempnam( sys_get_temp_dir(), 'codex-icons-' ) . '.json';
+		file_put_contents( $this->fixturePath, json_encode( self::FIXTURE_ICONS ) );
+	}
+
+	protected function tearDown(): void {
+		if ( file_exists( $this->fixturePath ) ) {
+			unlink( $this->fixturePath );
+		}
+	}
+
+	private function newResolver( string $scriptPath = '/w' ): IconResolver {
+		return new IconResolver( $this->fixturePath, $scriptPath );
+	}
+
+	public function testLtrShapeCodexIconBecomesDataUri(): void {
+		$result = $this->newResolver()->resolve( [
+			'groups' => [ 'bluelink' => [ 'image' => 'cdxIconArticle' ] ],
+		] );
+
+		$image = $result['groups']['bluelink']['image'];
+		$this->assertStringStartsWith( 'data:image/svg+xml;base64,', $image );
+
+		$decoded = base64_decode( substr( $image, strlen( 'data:image/svg+xml;base64,' ) ) );
+		$this->assertStringContainsString( '<svg ', $decoded );
+		$this->assertStringContainsString( 'viewBox="0 0 20 20"', $decoded );
+		$this->assertStringContainsString( '<path d="M5 1h10z"/>', $decoded );
+	}
+
+	public function testStringShapeCodexIconBecomesDataUri(): void {
+		$result = $this->newResolver()->resolve( [
+			'groups' => [ 'g' => [ 'image' => 'cdxIconAdd' ] ],
+		] );
+
+		$image = $result['groups']['g']['image'];
+		$this->assertStringStartsWith( 'data:image/svg+xml;base64,', $image );
+
+		$decoded = base64_decode( substr( $image, strlen( 'data:image/svg+xml;base64,' ) ) );
+		$this->assertStringContainsString( '<path d="M11 9V4z"/>', $decoded );
+	}
+
+	public function testDefaultShapeCodexIconBecomesDataUri(): void {
+		$result = $this->newResolver()->resolve( [
+			'groups' => [ 'g' => [ 'image' => 'cdxIconBold' ] ],
+		] );
+
+		$image = $result['groups']['g']['image'];
+		$this->assertStringStartsWith( 'data:image/svg+xml;base64,', $image );
+
+		$decoded = base64_decode( substr( $image, strlen( 'data:image/svg+xml;base64,' ) ) );
+		$this->assertStringContainsString( '<path d="M3 19h7z"/>', $decoded );
+	}
+
+	public function testUnknownCodexIconNameLeftUnchanged(): void {
+		$result = $this->newResolver()->resolve( [
+			'groups' => [ 'bluelink' => [ 'image' => 'cdxIconNonExistent' ] ],
+		] );
+
+		$this->assertSame( 'cdxIconNonExistent', $result['groups']['bluelink']['image'] );
+	}
+
+	public function testHttpsUrlLeftUnchanged(): void {
+		$result = $this->newResolver()->resolve( [
+			'groups' => [ 'g' => [ 'image' => 'https://example.com/foo.svg' ] ],
+		] );
+
+		$this->assertSame( 'https://example.com/foo.svg', $result['groups']['g']['image'] );
+	}
+
+	public function testProtocolRelativeUrlLeftUnchanged(): void {
+		$result = $this->newResolver()->resolve( [
+			'groups' => [ 'g' => [ 'image' => '//example.com/foo.svg' ] ],
+		] );
+
+		$this->assertSame( '//example.com/foo.svg', $result['groups']['g']['image'] );
+	}
+
+	public function testRootRelativeUrlLeftUnchanged(): void {
+		$result = $this->newResolver()->resolve( [
+			'groups' => [ 'g' => [ 'image' => '/wiki/foo.svg' ] ],
+		] );
+
+		$this->assertSame( '/wiki/foo.svg', $result['groups']['g']['image'] );
+	}
+
+	public function testDataUriLeftUnchanged(): void {
+		$dataUri = 'data:image/svg+xml;base64,PHN2Zy8+';
+		$result = $this->newResolver()->resolve( [
+			'groups' => [ 'g' => [ 'image' => $dataUri ] ],
+		] );
+
+		$this->assertSame( $dataUri, $result['groups']['g']['image'] );
+	}
+
+	public function testRelativePathPrefixedWithScriptPath(): void {
+		$result = $this->newResolver( '/w' )->resolve( [
+			'groups' => [ 'g' => [ 'image' => 'resources/lib/ooui/foo.svg' ] ],
+		] );
+
+		$this->assertSame( '/w/resources/lib/ooui/foo.svg', $result['groups']['g']['image'] );
+	}
+
+	public function testEmptyScriptPathStillProducesAbsolute(): void {
+		$result = $this->newResolver( '' )->resolve( [
+			'groups' => [ 'g' => [ 'image' => 'resources/lib/ooui/foo.svg' ] ],
+		] );
+
+		$this->assertSame( '/resources/lib/ooui/foo.svg', $result['groups']['g']['image'] );
+	}
+
+	public function testNoGroupsKeyTolerated(): void {
+		$input = [ 'nodes' => [ 'shape' => 'image' ] ];
+		$this->assertSame( $input, $this->newResolver()->resolve( $input ) );
+	}
+
+	public function testGroupsNotArrayTolerated(): void {
+		$input = [ 'groups' => 'not-an-array' ];
+		$this->assertSame( $input, $this->newResolver()->resolve( $input ) );
+	}
+
+	public function testGroupWithoutImageTolerated(): void {
+		$input = [
+			'groups' => [
+				'bluelink' => [ 'color' => 'blue' ],
+			],
+		];
+		$this->assertSame( $input, $this->newResolver()->resolve( $input ) );
+	}
+
+	public function testNonStringImageTolerated(): void {
+		$input = [
+			'groups' => [
+				'bluelink' => [ 'image' => 123 ],
+			],
+		];
+		$this->assertSame( $input, $this->newResolver()->resolve( $input ) );
+	}
+
+	public function testMultipleGroupsResolvedIndependently(): void {
+		$result = $this->newResolver( '/w' )->resolve( [
+			'groups' => [
+				'bluelink' => [ 'image' => 'cdxIconArticle' ],
+				'redlink' => [ 'image' => 'resources/foo.svg' ],
+				'externallink' => [ 'image' => 'cdxIconLinkExternal' ],
+				'fallback' => [ 'image' => 'https://example.com/x.svg' ],
+			],
+		] );
+
+		$this->assertStringStartsWith( 'data:image/svg+xml;base64,', $result['groups']['bluelink']['image'] );
+		$this->assertSame( '/w/resources/foo.svg', $result['groups']['redlink']['image'] );
+		$this->assertStringStartsWith( 'data:image/svg+xml;base64,', $result['groups']['externallink']['image'] );
+		$this->assertSame( 'https://example.com/x.svg', $result['groups']['fallback']['image'] );
+	}
+
+	public function testMissingIconsJsonFileTolerated(): void {
+		$resolver = new IconResolver( '/path/that/does/not/exist.json', '/w' );
+		$result = $resolver->resolve( [
+			'groups' => [ 'bluelink' => [ 'image' => 'cdxIconArticle' ] ],
+		] );
+
+		$this->assertSame( 'cdxIconArticle', $result['groups']['bluelink']['image'] );
+	}
+
+	public function testMalformedIconsJsonFileTolerated(): void {
+		file_put_contents( $this->fixturePath, 'not valid json {{{' );
+		$result = $this->newResolver()->resolve( [
+			'groups' => [ 'bluelink' => [ 'image' => 'cdxIconArticle' ] ],
+		] );
+
+		$this->assertSame( 'cdxIconArticle', $result['groups']['bluelink']['image'] );
+	}
+
+}

--- a/tests/php/NetworkFunction/NetworkUseCaseTest.php
+++ b/tests/php/NetworkFunction/NetworkUseCaseTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace MediaWiki\Extension\Network\Tests\NetworkFunction;
 
+use MediaWiki\Extension\Network\NetworkFunction\IconResolver;
 use MediaWiki\Extension\Network\NetworkFunction\NetworkUseCase;
 use MediaWiki\Extension\Network\NetworkFunction\RequestModel;
 use PHPUnit\Framework\TestCase;
@@ -14,6 +15,13 @@ use PHPUnit\Framework\TestCase;
 class NetworkUseCaseTest extends TestCase {
 
 	private const RENDERING_PAGE_NAME = 'MyPage';
+
+	private function newNoOpIconResolver(): IconResolver {
+		// Pointed at a nonexistent JSON file so cdxIcon names won't resolve;
+		// none of the existing tests pass groups[*].image, so the resolver is
+		// effectively a no-op for them.
+		return new IconResolver( '/dev/null', '' );
+	}
 
 	public function testDefaultPageName(): void {
 		$this->assertSame(
@@ -36,7 +44,7 @@ class NetworkUseCaseTest extends TestCase {
 				]
 			]
 		];
-		( new NetworkUseCase( $presenter, $visJsOptions ) )->run( $requestModel );
+		( new NetworkUseCase( $presenter, $visJsOptions, $this->newNoOpIconResolver() ) )->run( $requestModel );
 
 		return $presenter;
 	}
@@ -177,7 +185,7 @@ class NetworkUseCaseTest extends TestCase {
 
 	public function testNoOptionsInLocalSettingsAndNoOptionsParameter(): void {
 		$presenter = new SpyNetworkPresenter();
-		( new NetworkUseCase( $presenter, [] ) )->run( $this->newBasicRequestModel() );
+		( new NetworkUseCase( $presenter, [], $this->newNoOpIconResolver() ) )->run( $this->newBasicRequestModel() );
 
 		$this->assertSame(
 			[],
@@ -194,7 +202,7 @@ class NetworkUseCaseTest extends TestCase {
 		];
 
 		$presenter = new SpyNetworkPresenter();
-		( new NetworkUseCase( $presenter, $setting ) )->run( $this->newBasicRequestModel() );
+		( new NetworkUseCase( $presenter, $setting, $this->newNoOpIconResolver() ) )->run( $this->newBasicRequestModel() );
 
 		$this->assertEquals(
 			$setting,
@@ -207,7 +215,7 @@ class NetworkUseCaseTest extends TestCase {
 		$request->functionArguments = [ 'options={"nodes": {"shape": "box"}}' ];
 
 		$presenter = new SpyNetworkPresenter();
-		( new NetworkUseCase( $presenter, [] ) )->run( $request );
+		( new NetworkUseCase( $presenter, [], $this->newNoOpIconResolver() ) )->run( $request );
 
 		$this->assertSame(
 			[
@@ -232,7 +240,7 @@ class NetworkUseCaseTest extends TestCase {
 		$request->functionArguments = [ 'options={"nodes": {"shape": "box", "color": "red"}}' ];
 
 		$presenter = new SpyNetworkPresenter();
-		( new NetworkUseCase( $presenter, $setting ) )->run( $request );
+		( new NetworkUseCase( $presenter, $setting, $this->newNoOpIconResolver() ) )->run( $request );
 
 		$this->assertEquals(
 			[


### PR DESCRIPTION
<img width="675" height="562" alt="image" src="https://github.com/user-attachments/assets/6661cf0f-9439-46f8-9abf-e701482ab9b9" />


## Summary

Fixes default group icons (and OOUI Title Icons) 404'ing on wikis with pretty article URLs (`/wiki/Foo`). The root cause was the same in both call sites: bare relative paths handed to vis-network, which the browser then resolved against the document URL.

- **`PageNetworkOptions` defaults switch to canonical Codex icon names** — `cdxIconArticle`, `cdxIconArticleNotFound`, `cdxIconLinkExternal`. A new PHP unit `IconResolver` looks each name up in MediaWiki's bundled `resources/lib/codex-icons/codex-icons.json` and emits an inline SVG `data:` URI in `data-options`. The lookup tolerates all three icon shapes that the JSON ships (plain string, `{ltr, ...}`, and `{default, langCodeMap, ...}`); unknown names log a warning and fall through. Absolute URLs and `data:` URIs pass through unchanged. Other relative paths get prefixed with `$wgScriptPath` for backward-compat with users who configured MW-relative paths in `LocalSettings.php`.
- **OOUI Title Icon URL is prefixed with `mw.config.get('wgScriptPath')`** in `resources/js/ApiPageConnectionRepo.js` (defaulting to `''` when unset) so the URL is absolute regardless of article URL style. Title Icon's catalogue is OOUI-style; a Codex migration would need a name-mapping table and per-page user data — out of scope.

The resolver runs after the defaults+user-options merge in `NetworkUseCase::getVisJsOptions()`, so user-provided per-call options receive the same treatment. `Extension::getFactory()` reads paths via `MainConfigNames::BaseDirectory` and `MainConfigNames::ScriptPath`, no static-analysis suppressions needed.

## Test plan

- [x] `composer phpunit` — 36/36 (was 19; 17 new in `IconResolverTest`)
- [x] `vendor/bin/phpcs -p -s` — clean
- [x] `vendor/bin/phpstan analyse` (level 1) — No errors
- [x] `vendor/bin/psalm` (errorLevel 2) — No errors found
- [x] Runtime smoke against the local dev wiki — confirmed `data-options` contains valid `data:image/svg+xml;base64,…` URIs that decode to real Codex SVGs; icons render in the browser
- [x] CI: all five PHPUnit matrix rows + static-analysis + code-style pass

## Out of scope

- Per-group icon colour / theme adaptation. The bundled Codex SVGs render with their default fill (black). Wikis can override per group in `LocalSettings.php`. Worth a follow-up if the white-card-on-dark-theme look bothers anyone.
- Migrating Title Icon's OOUI icon names to Codex (per-page user data + name-mapping table).
- Refactoring the existing `MediaWikiServices::getInstance()` service-locator usage in `NetworkConfig`.